### PR TITLE
Add a sane default constructor for the Etcd and EtcdConfig structs

### DIFF
--- a/pkg/framework/test/apiserver_config.go
+++ b/pkg/framework/test/apiserver_config.go
@@ -8,6 +8,7 @@ type APIServerConfig struct {
 	APIServerURL string `valid:"required,url"`
 }
 
+// Validate checks that the config contains only valid URLs
 func (c *APIServerConfig) Validate() error {
 	_, err := govalidator.ValidateStruct(c)
 	return err

--- a/pkg/framework/test/bin_path_finder.go
+++ b/pkg/framework/test/bin_path_finder.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var assetsPath string
+
+func init() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("Could not determine the path of the BinPathFinder")
+	}
+	assetsPath = filepath.Join(filepath.Dir(thisFile), "assets", "bin")
+}
+
+// BinPathFinder is the signature of a function translating a symbolic name of a binary to
+// a resolvable path to the binary in question
+type BinPathFinder func(symbolicName string) (binPath string)
+
+// DefaultBinPathFinder is an implementation of BinPathFinder which checks the an environment
+// variable, derived from the symbolic name, and falls back to a default assets location when
+// this variable is not set
+func DefaultBinPathFinder(symbolicName string) (binPath string) {
+	envVar := "TEST_ASSET_" + strings.ToUpper(symbolicName)
+
+	if val, ok := os.LookupEnv(envVar); ok {
+		return val
+	}
+
+	return filepath.Join(assetsPath, symbolicName)
+}

--- a/pkg/framework/test/bin_path_finder_test.go
+++ b/pkg/framework/test/bin_path_finder_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DefaultBinPathFinder", func() {
+	Context("when relying on the default assets path", func() {
+		var (
+			previousAssetsPath string
+		)
+		BeforeEach(func() {
+			previousAssetsPath = assetsPath
+			assetsPath = "/some/path/assets/bin"
+		})
+		AfterEach(func() {
+			assetsPath = previousAssetsPath
+		})
+		It("returns the default path when no env var is configured", func() {
+			binPath := DefaultBinPathFinder("some_bin")
+			Expect(binPath).To(Equal("/some/path/assets/bin/some_bin"))
+		})
+	})
+
+	Context("when environment is configured", func() {
+		var (
+			previousValue string
+			wasSet        bool
+		)
+		BeforeEach(func() {
+			envVarName := "TEST_ASSET_ANOTHER_SYMBOLIC_NAME"
+			if val, ok := os.LookupEnv(envVarName); ok {
+				previousValue = val
+				wasSet = true
+			}
+			os.Setenv(envVarName, "/path/to/some_bin.exe")
+		})
+		AfterEach(func() {
+			if wasSet {
+				os.Setenv("TEST_ASSET_ANOTHER_SYMBOLIC_NAME", previousValue)
+			} else {
+				os.Unsetenv("TEST_ASSET_ANOTHER_SYMBOLIC_NAME")
+			}
+		})
+		It("returns the path from the env", func() {
+			binPath := DefaultBinPathFinder("another_symbolic_name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+		})
+	})
+})

--- a/pkg/framework/test/etcd.go
+++ b/pkg/framework/test/etcd.go
@@ -43,8 +43,29 @@ type SimpleSession interface {
 
 type simpleSessionStarter func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error)
 
-// NewEtcd constructs an Etcd Fixture Process
-func NewEtcd(pathToEtcd string, config *EtcdConfig) *Etcd {
+var etcdBinPathFinder = DefaultBinPathFinder
+
+// NewEtcd returns a Etcd process configured with sane defaults
+func NewEtcd() (*Etcd, error) {
+	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
+		return gexec.Start(command, out, err)
+	}
+
+	config, err := NewEtcdConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Etcd{
+		Path:           etcdBinPathFinder("etcd"),
+		ProcessStarter: starter,
+		DataDirManager: NewTempDirManager(),
+		Config:         config,
+	}, nil
+}
+
+// NewEtcdWithBinaryAndConfig returns a Etcd process, using the handed in binary and config.
+func NewEtcdWithBinaryAndConfig(pathToEtcd string, config *EtcdConfig) *Etcd {
 	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
 		return gexec.Start(command, out, err)
 	}

--- a/pkg/framework/test/etcd_config.go
+++ b/pkg/framework/test/etcd_config.go
@@ -8,6 +8,7 @@ type EtcdConfig struct {
 	PeerURL   string `valid:"required,url"`
 }
 
+// Validate checks that the config contains only valid URLs
 func (c *EtcdConfig) Validate() error {
 	_, err := govalidator.ValidateStruct(c)
 	return err

--- a/pkg/framework/test/etcd_config.go
+++ b/pkg/framework/test/etcd_config.go
@@ -1,11 +1,37 @@
 package test
 
-import "github.com/asaskevich/govalidator"
+import (
+	"fmt"
+
+	"github.com/asaskevich/govalidator"
+)
 
 // EtcdConfig is a struct holding data to configure the Etcd process
 type EtcdConfig struct {
 	ClientURL string `valid:"required,url"`
 	PeerURL   string `valid:"required,url"`
+}
+
+var etcdPortFinder = DefaultPortFinder
+
+// NewEtcdConfig returns a simple config for Etcd with sane default values
+func NewEtcdConfig() (etcdConfig *EtcdConfig, err error) {
+	conf := &EtcdConfig{}
+	host := "localhost"
+
+	if port, addr, err := etcdPortFinder(host); err == nil {
+		conf.ClientURL = fmt.Sprintf("http://%s:%d", addr, port)
+	} else {
+		return nil, err
+	}
+
+	if port, addr, err := etcdPortFinder(host); err == nil {
+		conf.PeerURL = fmt.Sprintf("http://%s:%d", addr, port)
+	} else {
+		return nil, err
+	}
+
+	return conf, nil
 }
 
 // Validate checks that the config contains only valid URLs

--- a/pkg/framework/test/etcd_config_test.go
+++ b/pkg/framework/test/etcd_config_test.go
@@ -1,36 +1,68 @@
-package test_test
+package test
 
 import (
-	. "k8s.io/kubectl/pkg/framework/test"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("EtcdConfig", func() {
-	It("does not error on valid config", func() {
-		conf := &EtcdConfig{
-			PeerURL:   "http://this.is.some.url:1234",
-			ClientURL: "http://this.is.another.url/",
-		}
-		err := conf.Validate()
-		Expect(err).NotTo(HaveOccurred())
-	})
+	Context("Constructor", func() {
+		var (
+			previousPortFinder PortFinder
+		)
+		BeforeEach(func() {
+			previousPortFinder = etcdPortFinder
+		})
+		AfterEach(func() {
+			etcdPortFinder = previousPortFinder
+		})
 
-	It("errors on empty config", func() {
-		conf := &EtcdConfig{}
-		err := conf.Validate()
-		Expect(err).To(MatchError(ContainSubstring("PeerURL: non zero value required")))
-		Expect(err).To(MatchError(ContainSubstring("ClientURL: non zero value required")))
-	})
+		It("sets some sane default URLs", func() {
+			etcdPortFinder = func(host string) (port int, addr string, err error) {
+				return 42, "1.2.3.4", nil
+			}
 
-	It("errors on malformed URLs", func() {
-		conf := &EtcdConfig{
-			PeerURL:   "something not URLish",
-			ClientURL: "something not URLesc",
-		}
-		err := conf.Validate()
-		Expect(err).To(MatchError(ContainSubstring("PeerURL: something not URLish does not validate as url")))
-		Expect(err).To(MatchError(ContainSubstring("ClientURL: something not URLesc does not validate as url")))
+			conf, err := NewEtcdConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conf.ClientURL).To(Equal("http://1.2.3.4:42"))
+		})
+
+		It("prop[agates and error while trying to find a port", func() {
+			etcdPortFinder = func(host string) (port int, addr string, err error) {
+				return 43, "5.6.7.8", fmt.Errorf("oh nooos, no port")
+			}
+
+			_, err := NewEtcdConfig()
+			Expect(err).To(MatchError(ContainSubstring("oh nooos, no port")))
+		})
+	})
+	Context("Validate()", func() {
+		It("does not error on valid config", func() {
+			conf := &EtcdConfig{
+				PeerURL:   "http://this.is.some.url:1234",
+				ClientURL: "http://this.is.another.url/",
+			}
+			err := conf.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("errors on empty config", func() {
+			conf := &EtcdConfig{}
+			err := conf.Validate()
+			Expect(err).To(MatchError(ContainSubstring("PeerURL: non zero value required")))
+			Expect(err).To(MatchError(ContainSubstring("ClientURL: non zero value required")))
+		})
+
+		It("errors on malformed URLs", func() {
+			conf := &EtcdConfig{
+				PeerURL:   "something not URLish",
+				ClientURL: "something not URLesc",
+			}
+			err := conf.Validate()
+			Expect(err).To(MatchError(ContainSubstring("PeerURL: something not URLish does not validate as url")))
+			Expect(err).To(MatchError(ContainSubstring("ClientURL: something not URLesc does not validate as url")))
+		})
 	})
 })

--- a/pkg/framework/test/etcd_constructor_test.go
+++ b/pkg/framework/test/etcd_constructor_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Etcd", func() {
+	Context("when constructed with the zero-config constructor", func() {
+		var (
+			previousBinPathFinder BinPathFinder
+		)
+		BeforeEach(func() {
+			previousBinPathFinder = etcdBinPathFinder
+			etcdBinPathFinder = func(name string) (binPath string) {
+				return "/the/path/to/etcd"
+			}
+		})
+		AfterEach(func() {
+			etcdBinPathFinder = previousBinPathFinder
+		})
+		It("gets a sensible path", func() {
+			etcd, err := NewEtcd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(etcd.Path).To(Equal("/the/path/to/etcd"))
+		})
+	})
+})

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -32,30 +32,22 @@ type FixtureProcess interface {
 
 // NewFixtures will give you a Fixtures struct that's properly wired together.
 func NewFixtures(pathToEtcd, pathToAPIServer string) (*Fixtures, error) {
-	etcdConfig := &EtcdConfig{}
+	etcdConfig, err := NewEtcdConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	apiServerConfig := &APIServerConfig{}
 
-	if url, err := getHTTPListenURL(); err == nil {
-		etcdConfig.ClientURL = url
-		apiServerConfig.EtcdURL = url
-	} else {
-		return nil, err
-	}
-
-	if url, err := getHTTPListenURL(); err == nil {
-		etcdConfig.PeerURL = url
-	} else {
-		return nil, err
-	}
-
-	if url, err := getHTTPListenURL(); err == nil {
+	if url, urlErr := getHTTPListenURL(); urlErr == nil {
 		apiServerConfig.APIServerURL = url
+		apiServerConfig.EtcdURL = etcdConfig.ClientURL
 	} else {
-		return nil, err
+		return nil, urlErr
 	}
 
 	fixtures := &Fixtures{
-		Etcd:      NewEtcd(pathToEtcd, etcdConfig),
+		Etcd:      NewEtcdWithBinaryAndConfig(pathToEtcd, etcdConfig),
 		APIServer: NewAPIServer(pathToAPIServer, apiServerConfig),
 	}
 

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -106,15 +106,20 @@ func getHTTPListenURL() (url string, err error) {
 	return fmt.Sprintf("http://%s:%d", host, port), nil
 }
 
-func getFreePort(host string) (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", host))
+func getFreePort(host string) (port int, err error) {
+	var addr *net.TCPAddr
+	addr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", host))
 	if err != nil {
-		return 0, err
+		return
 	}
-	l, err := net.ListenTCP("tcp", addr)
+	var l *net.TCPListener
+	l, err = net.ListenTCP("tcp", addr)
 	if err != nil {
-		return 0, err
+		return
 	}
-	defer l.Close()
+	defer func() {
+		err = l.Close()
+	}()
+
 	return l.Addr().(*net.TCPAddr).Port, nil
 }

--- a/pkg/framework/test/port_finder.go
+++ b/pkg/framework/test/port_finder.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"fmt"
+	"net"
+)
+
+// PortFinder is the signature of a function returning a free port and a resolved
+// address to listen/bind on, and an erro in case there were some problems finding
+// a free pair of address & port
+type PortFinder func(host string) (port int, resolvedAddress string, err error)
+
+// DefaultPortFinder is the default implementation of PortFinder: It resolves that
+// hostname or IP handed in and asks the kernel for a random port. To make that a bit
+// safer, it also tries to bind to that port to make sure it is not in use. If all goes
+// well the port and the resolved address are returned, otherwise the error is forwarded.
+func DefaultPortFinder(host string) (port int, resolvedAddress string, err error) {
+	var addr *net.TCPAddr
+	addr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", host))
+	if err != nil {
+		return
+	}
+	resolvedAddress = addr.IP.String()
+	var l *net.TCPListener
+	l, err = net.ListenTCP("tcp", addr)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = l.Close()
+	}()
+
+	return l.Addr().(*net.TCPAddr).Port, resolvedAddress, nil
+}

--- a/pkg/framework/test/port_finder_test.go
+++ b/pkg/framework/test/port_finder_test.go
@@ -1,0 +1,36 @@
+package test_test
+
+import (
+	. "k8s.io/kubectl/pkg/framework/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DefaultPortFinder", func() {
+	It("returns a free port and an address to bind to", func() {
+		port, addr, err := DefaultPortFinder("127.0.0.1")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addr).To(Equal("127.0.0.1"))
+		Expect(port).To(BeNumerically(">=", 1))
+		Expect(port).To(BeNumerically("<=", 65535))
+	})
+
+	It("errrors on invalid host", func() {
+		_, _, err := DefaultPortFinder("this is not a hostname")
+
+		Expect(err).To(MatchError(ContainSubstring("no such host")))
+	})
+
+	Context("when using a DNS name", func() {
+		It("returns a free port and an address to bind to", func() {
+			port, addr, err := DefaultPortFinder("localhost")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addr).To(Equal("127.0.0.1"))
+			Expect(port).To(BeNumerically(">=", 1))
+			Expect(port).To(BeNumerically("<=", 65535))
+		})
+	})
+})


### PR DESCRIPTION
[closes #161]

We need to do some calculation to find binary paths and free ports, so we can't make a 0-value Etcd struct useful. But we can provide a constructor that takes no arguments, and gives you good defaults.

Cc @hoegaarden @apelisse 