### PR TITLE
Finalize the interface of the Fixtures struct

### DIFF
--- a/pkg/framework/test/apiserver.go
+++ b/pkg/framework/test/apiserver.go
@@ -33,34 +33,18 @@ type certDirManager interface {
 
 var apiServerBinPathFinder = DefaultBinPathFinder
 
-// NewAPIServer constructs a new APIServer with whatever api_server binary it can find.
+// NewAPIServer creates a new APIServer Fixture Process
 func NewAPIServer(config *APIServerConfig) *APIServer {
 	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
 		return gexec.Start(command, out, err)
 	}
 
 	return &APIServer{
-		Path:           apiServerBinPathFinder("kube_apiserver"),
+		Path:           apiServerBinPathFinder("kube-apiserver"),
 		Config:         config,
-		ProcessStarter: starter,
-		CertDirManager: &TempDirManager{},
-	}
-}
-
-// NewAPIServerWithBinary creates a new APIServer Fixture Process
-func NewAPIServerWithBinary(pathToAPIServer string, config *APIServerConfig) *APIServer {
-	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
-		return gexec.Start(command, out, err)
-	}
-
-	apiserver := &APIServer{
-		Path:           pathToAPIServer,
 		ProcessStarter: starter,
 		CertDirManager: NewTempDirManager(),
-		Config:         config,
 	}
-
-	return apiserver
 }
 
 // Start starts the apiserver, waits for it to come up, and returns an error, if occoured.

--- a/pkg/framework/test/apiserver.go
+++ b/pkg/framework/test/apiserver.go
@@ -19,6 +19,7 @@ type APIServer struct {
 	ProcessStarter simpleSessionStarter
 	CertDirManager certDirManager
 	Config         *APIServerConfig
+	Etcd           FixtureProcess
 	session        SimpleSession
 	stdOut         *gbytes.Buffer
 	stdErr         *gbytes.Buffer
@@ -34,9 +35,14 @@ type certDirManager interface {
 var apiServerBinPathFinder = DefaultBinPathFinder
 
 // NewAPIServer creates a new APIServer Fixture Process
-func NewAPIServer(config *APIServerConfig) *APIServer {
+func NewAPIServer(config *APIServerConfig) (*APIServer, error) {
 	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
 		return gexec.Start(command, out, err)
+	}
+
+	etcd, err := NewEtcd()
+	if err != nil {
+		return nil, err
 	}
 
 	return &APIServer{
@@ -44,12 +50,23 @@ func NewAPIServer(config *APIServerConfig) *APIServer {
 		Config:         config,
 		ProcessStarter: starter,
 		CertDirManager: NewTempDirManager(),
-	}
+		Etcd:           etcd,
+	}, nil
+}
+
+// GetURL returns the URL APIServer is listening on. Clients can use this to connect to APIServer.
+func (s *APIServer) GetURL() string {
+	return s.Config.APIServerURL
 }
 
 // Start starts the apiserver, waits for it to come up, and returns an error, if occoured.
 func (s *APIServer) Start() error {
 	if err := s.Config.Validate(); err != nil {
+		return err
+	}
+
+	err := s.Etcd.Start()
+	if err != nil {
 		return err
 	}
 
@@ -74,7 +91,7 @@ func (s *APIServer) Start() error {
 		"--admission-control-config-file=",
 		"--bind-address=0.0.0.0",
 		"--storage-backend=etcd3",
-		fmt.Sprintf("--etcd-servers=%s", s.Config.EtcdURL),
+		fmt.Sprintf("--etcd-servers=%s", s.Etcd.GetURL()),
 		fmt.Sprintf("--cert-dir=%s", certDir),
 		fmt.Sprintf("--insecure-port=%s", clientURL.Port()),
 		fmt.Sprintf("--insecure-bind-address=%s", clientURL.Hostname()),
@@ -102,6 +119,7 @@ func (s *APIServer) Stop() {
 	if s.session != nil {
 		s.session.Terminate()
 		s.session.Wait(20 * time.Second)
+		s.Etcd.Stop()
 		err := s.CertDirManager.Destroy()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}

--- a/pkg/framework/test/apiserver.go
+++ b/pkg/framework/test/apiserver.go
@@ -54,8 +54,8 @@ func NewAPIServer(config *APIServerConfig) (*APIServer, error) {
 	}, nil
 }
 
-// GetURL returns the URL APIServer is listening on. Clients can use this to connect to APIServer.
-func (s *APIServer) GetURL() string {
+// URL returns the URL APIServer is listening on. Clients can use this to connect to APIServer.
+func (s *APIServer) URL() string {
 	return s.Config.APIServerURL
 }
 
@@ -91,7 +91,7 @@ func (s *APIServer) Start() error {
 		"--admission-control-config-file=",
 		"--bind-address=0.0.0.0",
 		"--storage-backend=etcd3",
-		fmt.Sprintf("--etcd-servers=%s", s.Etcd.GetURL()),
+		fmt.Sprintf("--etcd-servers=%s", s.Etcd.URL()),
 		fmt.Sprintf("--cert-dir=%s", certDir),
 		fmt.Sprintf("--insecure-port=%s", clientURL.Port()),
 		fmt.Sprintf("--insecure-bind-address=%s", clientURL.Hostname()),

--- a/pkg/framework/test/apiserver.go
+++ b/pkg/framework/test/apiserver.go
@@ -31,8 +31,24 @@ type certDirManager interface {
 
 //go:generate counterfeiter . certDirManager
 
-// NewAPIServer creates a new APIServer Fixture Process
-func NewAPIServer(pathToAPIServer string, config *APIServerConfig) *APIServer {
+var apiServerBinPathFinder = DefaultBinPathFinder
+
+// NewAPIServer constructs a new APIServer with whatever api_server binary it can find.
+func NewAPIServer(config *APIServerConfig) *APIServer {
+	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
+		return gexec.Start(command, out, err)
+	}
+
+	return &APIServer{
+		Path:           apiServerBinPathFinder("kube_apiserver"),
+		Config:         config,
+		ProcessStarter: starter,
+		CertDirManager: &TempDirManager{},
+	}
+}
+
+// NewAPIServerWithBinary creates a new APIServer Fixture Process
+func NewAPIServerWithBinary(pathToAPIServer string, config *APIServerConfig) *APIServer {
 	starter := func(command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
 		return gexec.Start(command, out, err)
 	}

--- a/pkg/framework/test/apiserver_config.go
+++ b/pkg/framework/test/apiserver_config.go
@@ -4,7 +4,6 @@ import "github.com/asaskevich/govalidator"
 
 // APIServerConfig is a struct holding data to configure the API Server process
 type APIServerConfig struct {
-	EtcdURL      string `valid:"url"`
 	APIServerURL string `valid:"required,url"`
 }
 

--- a/pkg/framework/test/apiserver_config.go
+++ b/pkg/framework/test/apiserver_config.go
@@ -4,7 +4,7 @@ import "github.com/asaskevich/govalidator"
 
 // APIServerConfig is a struct holding data to configure the API Server process
 type APIServerConfig struct {
-	EtcdURL      string `valid:"required,url"`
+	EtcdURL      string `valid:"url"`
 	APIServerURL string `valid:"required,url"`
 }
 

--- a/pkg/framework/test/apiserver_config_test.go
+++ b/pkg/framework/test/apiserver_config_test.go
@@ -11,7 +11,6 @@ var _ = Describe("APIServerConfig", func() {
 	It("does not error on valid config", func() {
 		conf := &APIServerConfig{
 			APIServerURL: "http://this.is.some.url:1234",
-			EtcdURL:      "http://this.is.another.url/with/a/path/we/dont/care/about",
 		}
 		err := conf.Validate()
 		Expect(err).NotTo(HaveOccurred())
@@ -26,7 +25,6 @@ var _ = Describe("APIServerConfig", func() {
 	It("errors on malformed URLs", func() {
 		conf := &APIServerConfig{
 			APIServerURL: "something not URLish",
-			EtcdURL:      "something not URLesc",
 		}
 		err := conf.Validate()
 		Expect(err).To(MatchError(ContainSubstring("APIServerURL: something not URLish does not validate as url")))

--- a/pkg/framework/test/apiserver_config_test.go
+++ b/pkg/framework/test/apiserver_config_test.go
@@ -21,7 +21,6 @@ var _ = Describe("APIServerConfig", func() {
 		conf := &APIServerConfig{}
 		err := conf.Validate()
 		Expect(err).To(MatchError(ContainSubstring("APIServerURL: non zero value required")))
-		Expect(err).To(MatchError(ContainSubstring("EtcdURL: non zero value required")))
 	})
 
 	It("errors on malformed URLs", func() {
@@ -31,6 +30,5 @@ var _ = Describe("APIServerConfig", func() {
 		}
 		err := conf.Validate()
 		Expect(err).To(MatchError(ContainSubstring("APIServerURL: something not URLish does not validate as url")))
-		Expect(err).To(MatchError(ContainSubstring("EtcdURL: something not URLesc does not validate as url")))
 	})
 })

--- a/pkg/framework/test/apiserver_constructor_test.go
+++ b/pkg/framework/test/apiserver_constructor_test.go
@@ -24,12 +24,14 @@ var _ = Describe("NewAPIServer", func() {
 			return "some api server path"
 		}
 
-		apiServer := NewAPIServer(config)
+		apiServer, err := NewAPIServer(config)
 
+		Expect(err).NotTo(HaveOccurred())
 		Expect(apiServer).NotTo(BeNil())
 		Expect(apiServer.ProcessStarter).NotTo(BeNil())
 		Expect(apiServer.CertDirManager).NotTo(BeNil())
 		Expect(apiServer.Path).To(Equal("some api server path"))
+		Expect(apiServer.Etcd).NotTo(BeNil())
 		Expect(apiServer.Config).To(Equal(config))
 	})
 })

--- a/pkg/framework/test/apiserver_constructor_test.go
+++ b/pkg/framework/test/apiserver_constructor_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewAPIServer", func() {
+	var oldAPIServerBinPathFinder BinPathFinder
+	BeforeEach(func() {
+		oldAPIServerBinPathFinder = apiServerBinPathFinder
+	})
+	AfterEach(func() {
+		apiServerBinPathFinder = oldAPIServerBinPathFinder
+	})
+
+	It("can construct a properly configured APIServer", func() {
+		config := &APIServerConfig{
+			EtcdURL:      "some etcd URL",
+			APIServerURL: "some APIServer URL",
+		}
+		apiServerBinPathFinder = func(name string) string {
+			Expect(name).To(Equal("kube_apiserver"))
+			return "some api server path"
+		}
+
+		apiServer := NewAPIServer(config)
+
+		Expect(apiServer).NotTo(BeNil())
+		Expect(apiServer.ProcessStarter).NotTo(BeNil())
+		Expect(apiServer.CertDirManager).NotTo(BeNil())
+		Expect(apiServer.Path).To(Equal("some api server path"))
+		Expect(apiServer.Config).To(Equal(config))
+	})
+})

--- a/pkg/framework/test/apiserver_constructor_test.go
+++ b/pkg/framework/test/apiserver_constructor_test.go
@@ -20,7 +20,7 @@ var _ = Describe("NewAPIServer", func() {
 			APIServerURL: "some APIServer URL",
 		}
 		apiServerBinPathFinder = func(name string) string {
-			Expect(name).To(Equal("kube_apiserver"))
+			Expect(name).To(Equal("kube-apiserver"))
 			return "some api server path"
 		}
 

--- a/pkg/framework/test/apiserver_constructor_test.go
+++ b/pkg/framework/test/apiserver_constructor_test.go
@@ -16,7 +16,6 @@ var _ = Describe("NewAPIServer", func() {
 
 	It("can construct a properly configured APIServer", func() {
 		config := &APIServerConfig{
-			EtcdURL:      "some etcd URL",
 			APIServerURL: "some APIServer URL",
 		}
 		apiServerBinPathFinder = func(name string) string {

--- a/pkg/framework/test/apiserver_test.go
+++ b/pkg/framework/test/apiserver_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Apiserver", func() {
 	})
 
 	It("can be queried for the URL it listens on", func() {
-		Expect(apiServer.GetURL()).To(Equal("http://this.is.the.API.server:8080"))
+		Expect(apiServer.URL()).To(Equal("http://this.is.the.API.server:8080"))
 	})
 
 	Context("when given a path to a binary that runs for a long time", func() {

--- a/pkg/framework/test/apiserver_test.go
+++ b/pkg/framework/test/apiserver_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Apiserver", func() {
 		fakeEtcdProcess = &testfakes.FakeFixtureProcess{}
 
 		apiServerConfig = &APIServerConfig{
-			EtcdURL:      "http://this.is.etcd:2345/",
 			APIServerURL: "http://this.is.the.API.server:8080",
 		}
 		apiServer = &APIServer{

--- a/pkg/framework/test/apiserver_test.go
+++ b/pkg/framework/test/apiserver_test.go
@@ -21,11 +21,13 @@ var _ = Describe("Apiserver", func() {
 		fakeCertDirManager *testfakes.FakeCertDirManager
 		apiServer          *APIServer
 		apiServerConfig    *APIServerConfig
+		fakeEtcdProcess    *testfakes.FakeFixtureProcess
 	)
 
 	BeforeEach(func() {
 		fakeSession = &testfakes.FakeSimpleSession{}
 		fakeCertDirManager = &testfakes.FakeCertDirManager{}
+		fakeEtcdProcess = &testfakes.FakeFixtureProcess{}
 
 		apiServerConfig = &APIServerConfig{
 			EtcdURL:      "http://this.is.etcd:2345/",
@@ -35,7 +37,12 @@ var _ = Describe("Apiserver", func() {
 			Path:           "",
 			CertDirManager: fakeCertDirManager,
 			Config:         apiServerConfig,
+			Etcd:           fakeEtcdProcess,
 		}
+	})
+
+	It("can be queried for the URL it listens on", func() {
+		Expect(apiServer.GetURL()).To(Equal("http://this.is.the.API.server:8080"))
 	})
 
 	Context("when given a path to a binary that runs for a long time", func() {
@@ -56,6 +63,10 @@ var _ = Describe("Apiserver", func() {
 			err := apiServer.Start()
 			Expect(err).NotTo(HaveOccurred())
 
+			By("starting Etcd")
+			Expect(fakeEtcdProcess.StartCallCount()).To(Equal(1),
+				"the Etcd process should be started exactly once")
+
 			Eventually(apiServer).Should(gbytes.Say("Everything is fine"))
 			Expect(fakeSession.ExitCodeCallCount()).To(Equal(0))
 			Expect(apiServer).NotTo(gexec.Exit())
@@ -64,6 +75,8 @@ var _ = Describe("Apiserver", func() {
 
 			By("Stopping the API Server")
 			apiServer.Stop()
+
+			Expect(fakeEtcdProcess.StopCallCount()).To(Equal(1))
 			Expect(apiServer).To(gexec.Exit(143))
 			Expect(fakeSession.TerminateCallCount()).To(Equal(1))
 			Expect(fakeSession.WaitCallCount()).To(Equal(1))
@@ -72,19 +85,32 @@ var _ = Describe("Apiserver", func() {
 		})
 	})
 
+	Context("when starting etcd fails", func() {
+		It("propagates the error, and does not start the process", func() {
+			fakeEtcdProcess.StartReturnsOnCall(0, fmt.Errorf("starting etcd failed"))
+			apiServer.ProcessStarter = func(Command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
+				Expect(true).To(BeFalse(),
+					"the api server process starter shouldn't be called if starting etcd fails")
+				return nil, nil
+			}
+
+			err := apiServer.Start()
+			Expect(err).To(MatchError(ContainSubstring("starting etcd failed")))
+		})
+	})
+
 	Context("when the certificate directory cannot be created", func() {
 		It("propagates the error, and does not start the process", func() {
 			fakeCertDirManager.CreateReturnsOnCall(0, "", fmt.Errorf("Error on cert directory creation."))
 
-			processStarterCounter := 0
 			apiServer.ProcessStarter = func(Command *exec.Cmd, out, err io.Writer) (SimpleSession, error) {
-				processStarterCounter += 1
-				return fakeSession, nil
+				Expect(true).To(BeFalse(),
+					"the api server process starter shouldn't be called if creating the cert dir fails")
+				return nil, nil
 			}
 
 			err := apiServer.Start()
 			Expect(err).To(MatchError(ContainSubstring("Error on cert directory creation.")))
-			Expect(processStarterCounter).To(Equal(0))
 		})
 	})
 

--- a/pkg/framework/test/bin_path_finder.go
+++ b/pkg/framework/test/bin_path_finder.go
@@ -3,6 +3,7 @@ package test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -25,7 +26,11 @@ type BinPathFinder func(symbolicName string) (binPath string)
 // variable, derived from the symbolic name, and falls back to a default assets location when
 // this variable is not set
 func DefaultBinPathFinder(symbolicName string) (binPath string) {
-	envVar := "TEST_ASSET_" + strings.ToUpper(symbolicName)
+	punctuationPattern := regexp.MustCompile("[^A-Z0-9]+")
+	sanitizedName := punctuationPattern.ReplaceAllString(strings.ToUpper(symbolicName), "_")
+	leadingNumberPattern := regexp.MustCompile("^[0-9]+")
+	sanitizedName = leadingNumberPattern.ReplaceAllString(sanitizedName, "")
+	envVar := "TEST_ASSET_" + sanitizedName
 
 	if val, ok := os.LookupEnv(envVar); ok {
 		return val

--- a/pkg/framework/test/bin_path_finder_test.go
+++ b/pkg/framework/test/bin_path_finder_test.go
@@ -49,5 +49,18 @@ var _ = Describe("DefaultBinPathFinder", func() {
 			binPath := DefaultBinPathFinder("another_symbolic_name")
 			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
 		})
+
+		It("sanitizes the environment variable name", func() {
+			By("cleaning all non-underscore punctuation")
+			binPath := DefaultBinPathFinder("another-symbolic name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			binPath = DefaultBinPathFinder("another+symbolic\\name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			binPath = DefaultBinPathFinder("another=symbolic.name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			By("removing numbers from the beginning of the name")
+			binPath = DefaultBinPathFinder("12another_symbolic_name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+		})
 	})
 })

--- a/pkg/framework/test/democli/integration/integration_suite_test.go
+++ b/pkg/framework/test/democli/integration/integration_suite_test.go
@@ -32,19 +32,14 @@ var _ = BeforeSuite(func() {
 	Expect(ok).NotTo(BeFalse())
 	defaultAssetsDir := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "assets", "bin"))
 	pathToEtcd := filepath.Join(defaultAssetsDir, "etcd")
-	pathToAPIServer := filepath.Join(defaultAssetsDir, "kube-apiserver")
 
 	if pathToBin, ok := os.LookupEnv("TEST_ETCD_BIN"); ok {
 		pathToEtcd = pathToBin
 	}
-	if pathToBin, ok := os.LookupEnv("TEST_APISERVER_BIN"); ok {
-		pathToAPIServer = pathToBin
-	}
 
 	Expect(pathToEtcd).NotTo(BeEmpty(), "Path to etcd cannot be empty, set $TEST_ETCD_BIN")
-	Expect(pathToAPIServer).NotTo(BeEmpty(), "Path to apiserver cannot be empty, set $TEST_APISERVER_BIN")
 
-	fixtures, err = test.NewFixtures(pathToEtcd, pathToAPIServer)
+	fixtures, err = test.NewFixtures(pathToEtcd)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = fixtures.Start()

--- a/pkg/framework/test/democli/integration/integration_suite_test.go
+++ b/pkg/framework/test/democli/integration/integration_suite_test.go
@@ -4,9 +4,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/onsi/gomega/gexec"
@@ -28,18 +25,7 @@ var _ = BeforeSuite(func() {
 	pathToDemoCommand, err = gexec.Build("k8s.io/kubectl/pkg/framework/test/democli/")
 	Expect(err).NotTo(HaveOccurred())
 
-	_, thisFile, _, ok := runtime.Caller(0)
-	Expect(ok).NotTo(BeFalse())
-	defaultAssetsDir := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "assets", "bin"))
-	pathToEtcd := filepath.Join(defaultAssetsDir, "etcd")
-
-	if pathToBin, ok := os.LookupEnv("TEST_ETCD_BIN"); ok {
-		pathToEtcd = pathToBin
-	}
-
-	Expect(pathToEtcd).NotTo(BeEmpty(), "Path to etcd cannot be empty, set $TEST_ETCD_BIN")
-
-	fixtures, err = test.NewFixtures(pathToEtcd)
+	fixtures, err = test.NewFixtures()
 	Expect(err).NotTo(HaveOccurred())
 
 	err = fixtures.Start()

--- a/pkg/framework/test/democli/integration/integration_test.go
+++ b/pkg/framework/test/democli/integration/integration_test.go
@@ -21,7 +21,8 @@ var _ = Describe("DemoCLI Integration", func() {
 	})
 
 	It("can get a list of pods", func() {
-		apiURL := fixtures.Config.APIServerURL
+		apiURL := fixtures.APIServerURL()
+
 		command := exec.Command(pathToDemoCommand, "listPods", "--api-url", apiURL)
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/framework/test/etcd.go
+++ b/pkg/framework/test/etcd.go
@@ -80,6 +80,11 @@ func NewEtcdWithBinaryAndConfig(pathToEtcd string, config *EtcdConfig) *Etcd {
 	return etcd
 }
 
+// GetURL returns the URL Etcd is listening on. Clients can use this to connect to Etcd.
+func (e *Etcd) GetURL() string {
+	return e.Config.ClientURL
+}
+
 // Start starts the etcd, waits for it to come up, and returns an error, if occoured.
 func (e *Etcd) Start() error {
 	if err := e.Config.Validate(); err != nil {

--- a/pkg/framework/test/etcd.go
+++ b/pkg/framework/test/etcd.go
@@ -80,8 +80,8 @@ func NewEtcdWithBinaryAndConfig(pathToEtcd string, config *EtcdConfig) *Etcd {
 	return etcd
 }
 
-// GetURL returns the URL Etcd is listening on. Clients can use this to connect to Etcd.
-func (e *Etcd) GetURL() string {
+// URL returns the URL Etcd is listening on. Clients can use this to connect to Etcd.
+func (e *Etcd) URL() string {
 	return e.Config.ClientURL
 }
 

--- a/pkg/framework/test/etcd_test.go
+++ b/pkg/framework/test/etcd_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Etcd", func() {
 	})
 
 	It("can be queried for the port it listens on", func() {
-		Expect(etcd.GetURL()).To(Equal("http://this.is.etcd.listening.for.clients:1234"))
+		Expect(etcd.URL()).To(Equal("http://this.is.etcd.listening.for.clients:1234"))
 	})
 
 	Context("when given a path to a binary that runs for a long time", func() {

--- a/pkg/framework/test/etcd_test.go
+++ b/pkg/framework/test/etcd_test.go
@@ -1,17 +1,15 @@
 package test_test
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
-
-	. "k8s.io/kubectl/pkg/framework/test"
-
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+	. "k8s.io/kubectl/pkg/framework/test"
 	"k8s.io/kubectl/pkg/framework/test/testfakes"
 )
 
@@ -37,6 +35,10 @@ var _ = Describe("Etcd", func() {
 			DataDirManager: fakeDataDirManager,
 			Config:         etcdConfig,
 		}
+	})
+
+	It("can be queried for the port it listens on", func() {
+		Expect(etcd.GetURL()).To(Equal("http://this.is.etcd.listening.for.clients:1234"))
 	})
 
 	Context("when given a path to a binary that runs for a long time", func() {

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -31,7 +31,7 @@ type FixtureProcess interface {
 //go:generate counterfeiter . FixtureProcess
 
 // NewFixtures will give you a Fixtures struct that's properly wired together.
-func NewFixtures(pathToEtcd string) (*Fixtures, error) {
+func NewFixtures() (*Fixtures, error) {
 	apiServerConfig := &APIServerConfig{}
 
 	if url, urlErr := getHTTPListenURL(); urlErr == nil {

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -10,13 +10,6 @@ import (
 // Right now, that means Etcd and your APIServer. This is likely to increase in future.
 type Fixtures struct {
 	APIServer FixtureProcess
-	Config    FixturesConfig
-}
-
-// FixturesConfig is a datastructure that exposes configuration that should be used by clients to talk
-// to the fixture processes.
-type FixturesConfig struct {
-	APIServerURL string
 }
 
 // FixtureProcess knows how to start and stop a Fixture processes.
@@ -25,7 +18,7 @@ type FixturesConfig struct {
 type FixtureProcess interface {
 	Start() error
 	Stop()
-	GetURL() string
+	URL() string
 }
 
 //go:generate counterfeiter . FixtureProcess
@@ -47,10 +40,6 @@ func NewFixtures() (*Fixtures, error) {
 
 	fixtures := &Fixtures{
 		APIServer: apiServer,
-	}
-
-	fixtures.Config = FixturesConfig{
-		APIServerURL: apiServerConfig.APIServerURL,
 	}
 
 	return fixtures, nil
@@ -83,6 +72,11 @@ func (f *Fixtures) Start() error {
 func (f *Fixtures) Stop() error {
 	f.APIServer.Stop()
 	return nil
+}
+
+// APIServerURL returns the URL to the APIServer. Clients can use this URL to connect to the APIServer.
+func (f *Fixtures) APIServerURL() string {
+	return f.APIServer.URL()
 }
 
 func getHTTPListenURL() (url string, err error) {

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -48,7 +48,7 @@ func NewFixtures(pathToEtcd, pathToAPIServer string) (*Fixtures, error) {
 
 	fixtures := &Fixtures{
 		Etcd:      NewEtcdWithBinaryAndConfig(pathToEtcd, etcdConfig),
-		APIServer: NewAPIServer(pathToAPIServer, apiServerConfig),
+		APIServer: NewAPIServerWithBinary(pathToAPIServer, apiServerConfig),
 	}
 
 	fixtures.Config = FixturesConfig{

--- a/pkg/framework/test/fixtures.go
+++ b/pkg/framework/test/fixtures.go
@@ -31,7 +31,7 @@ type FixtureProcess interface {
 //go:generate counterfeiter . FixtureProcess
 
 // NewFixtures will give you a Fixtures struct that's properly wired together.
-func NewFixtures(pathToEtcd, pathToAPIServer string) (*Fixtures, error) {
+func NewFixtures(pathToEtcd string) (*Fixtures, error) {
 	etcdConfig, err := NewEtcdConfig()
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func NewFixtures(pathToEtcd, pathToAPIServer string) (*Fixtures, error) {
 
 	fixtures := &Fixtures{
 		Etcd:      NewEtcdWithBinaryAndConfig(pathToEtcd, etcdConfig),
-		APIServer: NewAPIServerWithBinary(pathToAPIServer, apiServerConfig),
+		APIServer: NewAPIServer(apiServerConfig),
 	}
 
 	fixtures.Config = FixturesConfig{

--- a/pkg/framework/test/fixtures_test.go
+++ b/pkg/framework/test/fixtures_test.go
@@ -12,22 +12,18 @@ import (
 
 var _ = Describe("Fixtures", func() {
 	It("can construct a properly wired Fixtures struct", func() {
-		f, err := NewFixtures("path to etcd")
+		_, err := NewFixtures("path to etcd")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(f.Etcd.(*Etcd).Path).To(Equal("path to etcd"))
 	})
 
 	Context("with a properly configured set of Fixtures", func() {
 		var (
-			fakeEtcdProcess      *testfakes.FakeFixtureProcess
 			fakeAPIServerProcess *testfakes.FakeFixtureProcess
 			fixtures             Fixtures
 		)
 		BeforeEach(func() {
-			fakeEtcdProcess = &testfakes.FakeFixtureProcess{}
 			fakeAPIServerProcess = &testfakes.FakeFixtureProcess{}
 			fixtures = Fixtures{
-				Etcd:      fakeEtcdProcess,
 				APIServer: fakeAPIServerProcess,
 			}
 		})
@@ -36,21 +32,9 @@ var _ = Describe("Fixtures", func() {
 			err := fixtures.Start()
 			Expect(err).NotTo(HaveOccurred())
 
-			By("starting Etcd")
-			Expect(fakeEtcdProcess.StartCallCount()).To(Equal(1),
-				"the Etcd process should be started exactly once")
-
 			By("starting APIServer")
 			Expect(fakeAPIServerProcess.StartCallCount()).To(Equal(1),
 				"the APIServer process should be started exactly once")
-		})
-
-		Context("when starting etcd fails", func() {
-			It("wraps the error", func() {
-				fakeEtcdProcess.StartReturns(fmt.Errorf("some error"))
-				err := fixtures.Start()
-				Expect(err).To(MatchError(ContainSubstring("some error")))
-			})
 		})
 
 		Context("when starting APIServer fails", func() {
@@ -63,7 +47,6 @@ var _ = Describe("Fixtures", func() {
 
 		It("can can clean up the temporary directory and stop", func() {
 			fixtures.Stop()
-			Expect(fakeEtcdProcess.StopCallCount()).To(Equal(1))
 			Expect(fakeAPIServerProcess.StopCallCount()).To(Equal(1))
 		})
 

--- a/pkg/framework/test/fixtures_test.go
+++ b/pkg/framework/test/fixtures_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("Fixtures", func() {
 	It("can construct a properly wired Fixtures struct", func() {
-		_, err := NewFixtures("path to etcd")
+		_, err := NewFixtures()
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/framework/test/fixtures_test.go
+++ b/pkg/framework/test/fixtures_test.go
@@ -50,5 +50,12 @@ var _ = Describe("Fixtures", func() {
 			Expect(fakeAPIServerProcess.StopCallCount()).To(Equal(1))
 		})
 
+		It("can be queried for the APIServer URL", func() {
+			fakeAPIServerProcess.URLReturns("some url to the apiserver")
+
+			url := fixtures.APIServerURL()
+			Expect(url).To(Equal("some url to the apiserver"))
+		})
+
 	})
 })

--- a/pkg/framework/test/fixtures_test.go
+++ b/pkg/framework/test/fixtures_test.go
@@ -12,10 +12,9 @@ import (
 
 var _ = Describe("Fixtures", func() {
 	It("can construct a properly wired Fixtures struct", func() {
-		f, err := NewFixtures("path to etcd", "path to apiserver")
+		f, err := NewFixtures("path to etcd")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Etcd.(*Etcd).Path).To(Equal("path to etcd"))
-		Expect(f.APIServer.(*APIServer).Path).To(Equal("path to apiserver"))
 	})
 
 	Context("with a properly configured set of Fixtures", func() {

--- a/pkg/framework/test/integration/integration_suite_test.go
+++ b/pkg/framework/test/integration/integration_suite_test.go
@@ -4,9 +4,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/onsi/gomega/gexec"
@@ -16,23 +13,6 @@ func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Framework Integration Suite")
 }
-
-var (
-	defaultPathToEtcd string
-)
-
-var _ = BeforeSuite(func() {
-	_, thisFile, _, ok := runtime.Caller(0)
-	Expect(ok).NotTo(BeFalse())
-	defaultAssetsDir := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "assets", "bin"))
-	defaultPathToEtcd = filepath.Join(defaultAssetsDir, "etcd")
-
-	if pathToBin, ok := os.LookupEnv("TEST_ETCD_BIN"); ok {
-		defaultPathToEtcd = pathToBin
-	}
-
-	Expect(defaultPathToEtcd).NotTo(BeEmpty(), "Path to etcd cannot be empty, set $TEST_ETCD_BIN")
-})
 
 var _ = AfterSuite(func() {
 	gexec.TerminateAndWait()

--- a/pkg/framework/test/integration/integration_suite_test.go
+++ b/pkg/framework/test/integration/integration_suite_test.go
@@ -18,8 +18,7 @@ func TestIntegration(t *testing.T) {
 }
 
 var (
-	defaultPathToEtcd      string
-	defaultPathToApiserver string
+	defaultPathToEtcd string
 )
 
 var _ = BeforeSuite(func() {
@@ -27,17 +26,12 @@ var _ = BeforeSuite(func() {
 	Expect(ok).NotTo(BeFalse())
 	defaultAssetsDir := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "assets", "bin"))
 	defaultPathToEtcd = filepath.Join(defaultAssetsDir, "etcd")
-	defaultPathToApiserver = filepath.Join(defaultAssetsDir, "kube-apiserver")
 
 	if pathToBin, ok := os.LookupEnv("TEST_ETCD_BIN"); ok {
 		defaultPathToEtcd = pathToBin
 	}
-	if pathToBin, ok := os.LookupEnv("TEST_APISERVER_BIN"); ok {
-		defaultPathToApiserver = pathToBin
-	}
 
 	Expect(defaultPathToEtcd).NotTo(BeEmpty(), "Path to etcd cannot be empty, set $TEST_ETCD_BIN")
-	Expect(defaultPathToApiserver).NotTo(BeEmpty(), "Path to apiserver cannot be empty, set $TEST_APISERVER_BIN")
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/framework/test/integration/integration_test.go
+++ b/pkg/framework/test/integration/integration_test.go
@@ -25,25 +25,19 @@ var _ = Describe("The Testing Framework", func() {
 		Expect(err).NotTo(HaveOccurred(), "Expected fixtures to start successfully")
 
 		apiServerConf := fixtures.APIServer.(*test.APIServer).Config
-		etcdConf := fixtures.Etcd.(*test.Etcd).Config
 
-		var apiServerURL, etcdClientURL, etcdPeerURL *url.URL
-		etcdClientURL, err = url.Parse(etcdConf.ClientURL)
-		Expect(err).NotTo(HaveOccurred())
-		etcdPeerURL, err = url.Parse(etcdConf.PeerURL)
+		var apiServerURL, etcdClientURL *url.URL
+		etcdClientURL, err = url.Parse(fixtures.APIServer.(*test.APIServer).Etcd.GetURL())
 		Expect(err).NotTo(HaveOccurred())
 		apiServerURL, err = url.Parse(apiServerConf.APIServerURL)
 		Expect(err).NotTo(HaveOccurred())
 
 		isEtcdListeningForClients := isSomethingListeningOnPort(etcdClientURL.Host)
-		isEtcdListeningForPeers := isSomethingListeningOnPort(etcdPeerURL.Host)
 		isAPIServerListening := isSomethingListeningOnPort(apiServerURL.Host)
 
 		By("Ensuring Etcd is listening")
 		Expect(isEtcdListeningForClients()).To(BeTrue(),
 			fmt.Sprintf("Expected Etcd to listen for clients on %s,", etcdClientURL.Host))
-		Expect(isEtcdListeningForPeers()).To(BeTrue(),
-			fmt.Sprintf("Expected Etcd to listen for peers on %s,", etcdPeerURL.Host))
 
 		By("Ensuring APIServer is listening")
 		Expect(isAPIServerListening()).To(BeTrue(),
@@ -55,7 +49,6 @@ var _ = Describe("The Testing Framework", func() {
 
 		By("Ensuring Etcd is not listening anymore")
 		Expect(isEtcdListeningForClients()).To(BeFalse(), "Expected Etcd not to listen for clients anymore")
-		Expect(isEtcdListeningForPeers()).To(BeFalse(), "Expected Etcd not to listen for peers anymore")
 
 		By("Ensuring APIServer is not listening anymore")
 		Expect(isAPIServerListening()).To(BeFalse(), "Expected APIServer not to listen anymore")

--- a/pkg/framework/test/integration/integration_test.go
+++ b/pkg/framework/test/integration/integration_test.go
@@ -17,7 +17,7 @@ var _ = Describe("The Testing Framework", func() {
 		var err error
 		var fixtures *test.Fixtures
 
-		fixtures, err = test.NewFixtures(defaultPathToEtcd)
+		fixtures, err = test.NewFixtures()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Starting all the fixture processes")
@@ -56,7 +56,7 @@ var _ = Describe("The Testing Framework", func() {
 
 	Measure("It should be fast to bring up and tear down the fixtures", func(b Benchmarker) {
 		b.Time("lifecycle", func() {
-			fixtures, err := test.NewFixtures(defaultPathToEtcd)
+			fixtures, err := test.NewFixtures()
 			Expect(err).NotTo(HaveOccurred())
 
 			fixtures.Start()

--- a/pkg/framework/test/integration/integration_test.go
+++ b/pkg/framework/test/integration/integration_test.go
@@ -24,12 +24,10 @@ var _ = Describe("The Testing Framework", func() {
 		err = fixtures.Start()
 		Expect(err).NotTo(HaveOccurred(), "Expected fixtures to start successfully")
 
-		apiServerConf := fixtures.APIServer.(*test.APIServer).Config
-
 		var apiServerURL, etcdClientURL *url.URL
-		etcdClientURL, err = url.Parse(fixtures.APIServer.(*test.APIServer).Etcd.GetURL())
+		etcdClientURL, err = url.Parse(fixtures.APIServer.(*test.APIServer).Etcd.URL())
 		Expect(err).NotTo(HaveOccurred())
-		apiServerURL, err = url.Parse(apiServerConf.APIServerURL)
+		apiServerURL, err = url.Parse(fixtures.APIServerURL())
 		Expect(err).NotTo(HaveOccurred())
 
 		isEtcdListeningForClients := isSomethingListeningOnPort(etcdClientURL.Host)

--- a/pkg/framework/test/integration/integration_test.go
+++ b/pkg/framework/test/integration/integration_test.go
@@ -17,7 +17,7 @@ var _ = Describe("The Testing Framework", func() {
 		var err error
 		var fixtures *test.Fixtures
 
-		fixtures, err = test.NewFixtures(defaultPathToEtcd, defaultPathToApiserver)
+		fixtures, err = test.NewFixtures(defaultPathToEtcd)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Starting all the fixture processes")
@@ -63,7 +63,7 @@ var _ = Describe("The Testing Framework", func() {
 
 	Measure("It should be fast to bring up and tear down the fixtures", func(b Benchmarker) {
 		b.Time("lifecycle", func() {
-			fixtures, err := test.NewFixtures(defaultPathToEtcd, defaultPathToApiserver)
+			fixtures, err := test.NewFixtures(defaultPathToEtcd)
 			Expect(err).NotTo(HaveOccurred())
 
 			fixtures.Start()

--- a/pkg/framework/test/testfakes/fake_fixture_process.go
+++ b/pkg/framework/test/testfakes/fake_fixture_process.go
@@ -17,9 +17,18 @@ type FakeFixtureProcess struct {
 	startReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StopStub         func()
-	stopMutex        sync.RWMutex
-	stopArgsForCall  []struct{}
+	StopStub          func()
+	stopMutex         sync.RWMutex
+	stopArgsForCall   []struct{}
+	GetURLStub        func() string
+	getURLMutex       sync.RWMutex
+	getURLArgsForCall []struct{}
+	getURLReturns     struct {
+		result1 string
+	}
+	getURLReturnsOnCall map[int]struct {
+		result1 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -80,6 +89,46 @@ func (fake *FakeFixtureProcess) StopCallCount() int {
 	return len(fake.stopArgsForCall)
 }
 
+func (fake *FakeFixtureProcess) GetURL() string {
+	fake.getURLMutex.Lock()
+	ret, specificReturn := fake.getURLReturnsOnCall[len(fake.getURLArgsForCall)]
+	fake.getURLArgsForCall = append(fake.getURLArgsForCall, struct{}{})
+	fake.recordInvocation("GetURL", []interface{}{})
+	fake.getURLMutex.Unlock()
+	if fake.GetURLStub != nil {
+		return fake.GetURLStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.getURLReturns.result1
+}
+
+func (fake *FakeFixtureProcess) GetURLCallCount() int {
+	fake.getURLMutex.RLock()
+	defer fake.getURLMutex.RUnlock()
+	return len(fake.getURLArgsForCall)
+}
+
+func (fake *FakeFixtureProcess) GetURLReturns(result1 string) {
+	fake.GetURLStub = nil
+	fake.getURLReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeFixtureProcess) GetURLReturnsOnCall(i int, result1 string) {
+	fake.GetURLStub = nil
+	if fake.getURLReturnsOnCall == nil {
+		fake.getURLReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.getURLReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeFixtureProcess) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -87,6 +136,8 @@ func (fake *FakeFixtureProcess) Invocations() map[string][][]interface{} {
 	defer fake.startMutex.RUnlock()
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
+	fake.getURLMutex.RLock()
+	defer fake.getURLMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/framework/test/testfakes/fake_fixture_process.go
+++ b/pkg/framework/test/testfakes/fake_fixture_process.go
@@ -17,16 +17,16 @@ type FakeFixtureProcess struct {
 	startReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StopStub          func()
-	stopMutex         sync.RWMutex
-	stopArgsForCall   []struct{}
-	GetURLStub        func() string
-	getURLMutex       sync.RWMutex
-	getURLArgsForCall []struct{}
-	getURLReturns     struct {
+	StopStub        func()
+	stopMutex       sync.RWMutex
+	stopArgsForCall []struct{}
+	URLStub         func() string
+	uRLMutex        sync.RWMutex
+	uRLArgsForCall  []struct{}
+	uRLReturns      struct {
 		result1 string
 	}
-	getURLReturnsOnCall map[int]struct {
+	uRLReturnsOnCall map[int]struct {
 		result1 string
 	}
 	invocations      map[string][][]interface{}
@@ -89,42 +89,42 @@ func (fake *FakeFixtureProcess) StopCallCount() int {
 	return len(fake.stopArgsForCall)
 }
 
-func (fake *FakeFixtureProcess) GetURL() string {
-	fake.getURLMutex.Lock()
-	ret, specificReturn := fake.getURLReturnsOnCall[len(fake.getURLArgsForCall)]
-	fake.getURLArgsForCall = append(fake.getURLArgsForCall, struct{}{})
-	fake.recordInvocation("GetURL", []interface{}{})
-	fake.getURLMutex.Unlock()
-	if fake.GetURLStub != nil {
-		return fake.GetURLStub()
+func (fake *FakeFixtureProcess) URL() string {
+	fake.uRLMutex.Lock()
+	ret, specificReturn := fake.uRLReturnsOnCall[len(fake.uRLArgsForCall)]
+	fake.uRLArgsForCall = append(fake.uRLArgsForCall, struct{}{})
+	fake.recordInvocation("URL", []interface{}{})
+	fake.uRLMutex.Unlock()
+	if fake.URLStub != nil {
+		return fake.URLStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.getURLReturns.result1
+	return fake.uRLReturns.result1
 }
 
-func (fake *FakeFixtureProcess) GetURLCallCount() int {
-	fake.getURLMutex.RLock()
-	defer fake.getURLMutex.RUnlock()
-	return len(fake.getURLArgsForCall)
+func (fake *FakeFixtureProcess) URLCallCount() int {
+	fake.uRLMutex.RLock()
+	defer fake.uRLMutex.RUnlock()
+	return len(fake.uRLArgsForCall)
 }
 
-func (fake *FakeFixtureProcess) GetURLReturns(result1 string) {
-	fake.GetURLStub = nil
-	fake.getURLReturns = struct {
+func (fake *FakeFixtureProcess) URLReturns(result1 string) {
+	fake.URLStub = nil
+	fake.uRLReturns = struct {
 		result1 string
 	}{result1}
 }
 
-func (fake *FakeFixtureProcess) GetURLReturnsOnCall(i int, result1 string) {
-	fake.GetURLStub = nil
-	if fake.getURLReturnsOnCall == nil {
-		fake.getURLReturnsOnCall = make(map[int]struct {
+func (fake *FakeFixtureProcess) URLReturnsOnCall(i int, result1 string) {
+	fake.URLStub = nil
+	if fake.uRLReturnsOnCall == nil {
+		fake.uRLReturnsOnCall = make(map[int]struct {
 			result1 string
 		})
 	}
-	fake.getURLReturnsOnCall[i] = struct {
+	fake.uRLReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
 }
@@ -136,8 +136,8 @@ func (fake *FakeFixtureProcess) Invocations() map[string][][]interface{} {
 	defer fake.startMutex.RUnlock()
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
-	fake.getURLMutex.RLock()
-	defer fake.getURLMutex.RUnlock()
+	fake.uRLMutex.RLock()
+	defer fake.uRLMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
[closes #163]

In the process of making the APIServer constructor take 0 arguments (#162), we naturally find ourselves making the Fixtures constructor take 0 arguments (#163).

We'll be cleaning things up even more as we continue to work on #162, but this seems like a reasonable mid-point where there's already some user-value. In particular, the main interface to the test framework (The Fixtures constructor and methods) ought to be stable now:

```go
myFixtures, err := test.NewFixtures()
err = myFixtures.Start()
myServerURL = myFixtures.APIServerURL()
// Run tests using myServerURL
err = myFixtures.Stop()
```

Cc @hoegaarden @apelisse 