### PR TITLE
pre-commit: Check gofmt output for errors

### DIFF
--- a/bin/pre-commit.sh
+++ b/bin/pre-commit.sh
@@ -15,7 +15,7 @@ go_dirs() {
 }
 
 echo "Running go fmt"
-go_dirs | xargs -0 gofmt -s -d -l
+diff <(echo -n) <(go_dirs | xargs -0 gofmt -s -d -l)
 rc=$((rc || $?))
 
 echo "Running goimports"


### PR DESCRIPTION
gofmt doesn't return an error exit code when it fails (because some
files are improperly formatted). Make sure that the output is empty
instead.