### PR TITLE
kinflate: Separate 'resources' from 'packages'

### DIFF
--- a/pkg/apis/manifest/v1alpha1/types.go
+++ b/pkg/apis/manifest/v1alpha1/types.go
@@ -87,6 +87,9 @@ type Manifest struct {
 	// URLs and globs.
 	Resources []string `json:"resources,omitempty" yaml:"resources,omitempty"`
 
+	// Relative path to other packages directories..
+	Packages []string `json:"packages,omitempty" yaml:"packages,omitempty"`
+
 	// An Patch entry is very similar to an Resource entry.
 	// It specifies the relative paths within the package, and could be any
 	// format that kubectl -f allows.

--- a/pkg/kinflate/examples/simple/instances/exampleinstance/Kube-manifest.yaml
+++ b/pkg/kinflate/examples/simple/instances/exampleinstance/Kube-manifest.yaml
@@ -15,7 +15,7 @@ objectLabels:
   repo: test-infra
 objectAnnotations:
   note: This is a test annotation
-resources:
+packages:
 - ../../package
 #These are strategic merge patch overlays in the form of API resources
 patches:


### PR DESCRIPTION
I've been trying kinflate and have two feedbacks:

##### 1. Should not be forced to use 'overlays'
The initial proposal differentiated Overlays and BaseManifests but we later concluded that they could be merged into the resource Manifest, which can *optionally* include other Manifests.
 
In the current version, a user can't inflate a package that doesn't reference an another package
``` shell
$ kinflate -f pkg/kinflate/examples/simple/package/
error: open pkg/kinflate/examples/simple/package/deployment/deployment.yaml/Kube-manifest.yaml: not a directory
```
`simple/package/Kube-manifest.yaml`  is a valid manifest and the expected output is:
```yaml
---
apiVersion: v1
kind: Service
metadata:
  annotations: {}
  labels:
    app: mungebot
  name: mungebot-service
spec:
  ports:
  - port: 7002
  selector:
    app: mungebot
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  annotations: {}
  labels:
    app: mungebot
  name: mungebot
spec:
  replicas: 1
  template:
    annotations: {}
    metadata:
      labels:
        app: mungebot
    spec:
      containers:
      - env:
        - name: foo
          value: bar
        image: nginx
        name: nginx
        ports:
        - containerPort: 80
```

##### 2. Can't include new resources in 'overlays'
The `resources` field is used for two distinct purposes and they can't be mixed
 - Reference other packages
 - Include resources

It should be possible to include additional resources to a package (e.g. an ingress) 
I propose to add a new field 'packages'  instead of mixing them under the `resources` field. 
```
packages:
  ../../package
resources:
 - files/ingress.yaml
```

cc @monopole / @mengqiy 
