### PR TITLE
Checkpoint toward better kinflate error messages.

### DIFF
--- a/pkg/kinflate/commands/inflate.go
+++ b/pkg/kinflate/commands/inflate.go
@@ -83,8 +83,8 @@ func (o *inflateOptions) Complete(cmd *cobra.Command, args []string) error {
 // RunKinflate runs inflate command (do real work).
 func (o *inflateOptions) RunKinflate(out, errOut io.Writer) error {
 	// Build a tree of ManifestData.
-	loader := tree.Loader{FS: fs.MakeRealFS(), Path: o.manifestPath}
-	root, err := loader.LoadManifestDataFromPath(o.manifestPath)
+	loader := tree.Loader{FS: fs.MakeRealFS(), InitialPath: o.manifestPath}
+	root, err := loader.LoadManifestDataFromPath()
 	if err != nil {
 		return err
 	}

--- a/pkg/kinflate/commands/inflate.go
+++ b/pkg/kinflate/commands/inflate.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubectl/pkg/kinflate/tree"
 	"k8s.io/kubectl/pkg/kinflate/types"
 	kutil "k8s.io/kubectl/pkg/kinflate/util"
+	"k8s.io/kubectl/pkg/kinflate/util/fs"
 )
 
 type inflateOptions struct {
@@ -82,7 +83,8 @@ func (o *inflateOptions) Complete(cmd *cobra.Command, args []string) error {
 // RunKinflate runs inflate command (do real work).
 func (o *inflateOptions) RunKinflate(out, errOut io.Writer) error {
 	// Build a tree of ManifestData.
-	root, err := tree.LoadManifestDataFromPath(o.manifestPath)
+	loader := tree.Loader{FS: fs.MakeRealFS(), Path: o.manifestPath}
+	root, err := loader.LoadManifestDataFromPath(o.manifestPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/kinflate/tree/builder_test.go
+++ b/pkg/kinflate/tree/builder_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
 	"k8s.io/kubectl/pkg/kinflate/types"
+	"k8s.io/kubectl/pkg/kinflate/util/fs"
 )
 
 func makeMapOfConfigMap() types.KObject {
@@ -129,9 +130,11 @@ func TestFileToMap(t *testing.T) {
 		},
 	}
 
+	loader := Loader{FS: fs.MakeRealFS()}
+
 	for _, tc := range testcases {
 		actual := types.KObject{}
-		err := loadKObjectFromFile(tc.filename, actual)
+		err := loader.LoadKObjectFromFile(tc.filename, actual)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filename: %q, expect an error containing %q, but didn't get an error", tc.filename, tc.errorStr)
@@ -179,9 +182,11 @@ func TestPathToMap(t *testing.T) {
 		},
 	}
 
+	loader := Loader{FS: fs.MakeRealFS()}
+
 	for _, tc := range testcases {
 		actual := types.KObject{}
-		err := loadKObjectFromPath(tc.filename, actual)
+		err := loader.LoadKObjectFromPath(tc.filename, actual)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filename: %q, expect an error containing %q, but didn't get an error", tc.filename, tc.errorStr)
@@ -240,8 +245,10 @@ func TestPathsToMap(t *testing.T) {
 		},
 	}
 
+	loader := Loader{FS: fs.MakeRealFS()}
+
 	for _, tc := range testcases {
-		actual, err := loadKObjectFromPaths(tc.filenames)
+		actual, err := loader.LoadKObjectFromPaths(tc.filenames)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filenames: %q, expect an error containing %q, but didn't get an error", tc.filenames, tc.errorStr)
@@ -301,7 +308,8 @@ func TestManifestToManifestData(t *testing.T) {
 		Secrets:           SecretsType(types.KObject{}),
 	}
 
-	actual, err := loadManifestDataFromManifestFileAndResources(m)
+	loader := Loader{FS: fs.MakeRealFS()}
+	actual, err := loader.loadManifestDataFromManifestFileAndResources(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -321,8 +329,9 @@ func TestLoadManifestDataFromPath(t *testing.T) {
 	parent1.Packages = []*ManifestData{child1}
 	parent2.Packages = []*ManifestData{child2}
 
+	loader := Loader{FS: fs.MakeRealFS()}
 	expected := grandparent
-	actual, err := loadManifestDataFromPath("testdata/hierarchy")
+	actual, err := loader.loadManifestDataFromPath("testdata/hierarchy")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/kinflate/tree/builder_test.go
+++ b/pkg/kinflate/tree/builder_test.go
@@ -130,11 +130,12 @@ func TestFileToMap(t *testing.T) {
 		},
 	}
 
+	// TODO: Convert to a fake filesystem instead of using test files.
 	loader := Loader{FS: fs.MakeRealFS()}
 
 	for _, tc := range testcases {
 		actual := types.KObject{}
-		err := loader.LoadKObjectFromFile(tc.filename, actual)
+		err := loader.loadKObjectFromFile(tc.filename, actual)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filename: %q, expect an error containing %q, but didn't get an error", tc.filename, tc.errorStr)
@@ -182,11 +183,12 @@ func TestPathToMap(t *testing.T) {
 		},
 	}
 
+	// TODO: Convert to a fake filesystem instead of using test files.
 	loader := Loader{FS: fs.MakeRealFS()}
 
 	for _, tc := range testcases {
 		actual := types.KObject{}
-		err := loader.LoadKObjectFromPath(tc.filename, actual)
+		err := loader.loadKObjectFromPath(tc.filename, actual)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filename: %q, expect an error containing %q, but didn't get an error", tc.filename, tc.errorStr)
@@ -245,10 +247,11 @@ func TestPathsToMap(t *testing.T) {
 		},
 	}
 
+	// TODO: Convert to a fake filesystem instead of using test files.
 	loader := Loader{FS: fs.MakeRealFS()}
 
 	for _, tc := range testcases {
-		actual, err := loader.LoadKObjectFromPaths(tc.filenames)
+		actual, err := loader.loadKObjectFromPaths(tc.filenames)
 		if err == nil {
 			if tc.expectErr {
 				t.Errorf("filenames: %q, expect an error containing %q, but didn't get an error", tc.filenames, tc.errorStr)
@@ -308,6 +311,7 @@ func TestManifestToManifestData(t *testing.T) {
 		Secrets:           SecretsType(types.KObject{}),
 	}
 
+	// TODO: Convert to a fake filesystem instead of using test files.
 	loader := Loader{FS: fs.MakeRealFS()}
 	actual, err := loader.loadManifestDataFromManifestFileAndResources(m)
 	if err != nil {
@@ -329,9 +333,9 @@ func TestLoadManifestDataFromPath(t *testing.T) {
 	parent1.Packages = []*ManifestData{child1}
 	parent2.Packages = []*ManifestData{child2}
 
-	loader := Loader{FS: fs.MakeRealFS()}
+	loader := Loader{FS: fs.MakeRealFS(), InitialPath: "testdata/hierarchy"}
 	expected := grandparent
-	actual, err := loader.loadManifestDataFromPath("testdata/hierarchy")
+	actual, err := loader.LoadManifestDataFromPath()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/kinflate/util/manifestloader.go
+++ b/pkg/kinflate/util/manifestloader.go
@@ -33,6 +33,10 @@ type ManifestLoader struct {
 	FS fs.FileSystem
 }
 
+//This is a placeholder for the ManifestErrors type
+//TODO: Think about this struct and make is better
+type ManifestErrors []string
+
 func (m *ManifestLoader) fs() fs.FileSystem {
 	if m.FS == nil {
 		m.FS = fs.MakeRealFS()
@@ -43,7 +47,7 @@ func (m *ManifestLoader) fs() fs.FileSystem {
 // makeValidManifestPath returns a path to a KubeManifest file known to exist.
 // The argument is either the full path to the file itself, or a path to a directory
 // that immediately contains the file. Anything else is an error.
-func (m *ManifestLoader) makeValidManifestPath(mPath string) (string, error) {
+func (m *ManifestLoader) MakeValidManifestPath(mPath string) (string, error) {
 	f, err := m.fs().Stat(mPath)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Manifest (%s) missing\nRun `kinflate init` first", mPath)
@@ -65,11 +69,7 @@ func (m *ManifestLoader) makeValidManifestPath(mPath string) (string, error) {
 }
 
 // Read loads a manifest file and parse it in to the Manifest object.
-func (m *ManifestLoader) Read(mPath string) (*manifest.Manifest, error) {
-	filename, err := m.makeValidManifestPath(mPath)
-	if err != nil {
-		return nil, err
-	}
+func (m *ManifestLoader) Read(filename string) (*manifest.Manifest, error) {
 	bytes, err := m.fs().ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -96,4 +96,26 @@ func (m *ManifestLoader) Write(filename string, manifest *manifest.Manifest) err
 	}
 
 	return m.fs().WriteFile(filename, bytes)
+}
+
+// Read must have already been called and we have a loaded manifest
+func (m *ManifestLoader) Validate(manifest *manifest.Manifest) ManifestErrors {
+	//TODO: implement this function
+	//// validate Packages
+	//merrors := m.validatePackages(manifest.Packages)
+	//// validate Resources
+	//merrors = merrors + m.validateResources(manifest.Resources)
+	//
+	//// validate Patches
+	//merrors = append(merrors, m.validatePatches(manifest.Patches))
+	//
+	//// validate Configmaps
+	//merrors = append(merrors, m.validateConfigmaps(manifest.Configmaps))
+	//
+	//// validate GenericSecrets
+	//merrors = append(merrors, m.validateGenericSecrets(manifest.GenericSecrets))
+	//
+	//// validate TLSSecrets
+	//merrors = append(merrors, m.validateTLSSecrets(manifest.TLSSecrets))
+	return nil
 }

--- a/pkg/kinflate/util/manifestloader.go
+++ b/pkg/kinflate/util/manifestloader.go
@@ -33,9 +33,11 @@ type ManifestLoader struct {
 	FS fs.FileSystem
 }
 
-//This is a placeholder for the ManifestErrors type
-//TODO: Think about this struct and make is better
-type ManifestErrors []string
+// First pass to encapsulate fields for more informative error messages.
+type ManifestErrors struct {
+	filepath string
+	errorMsg string
+}
 
 func (m *ManifestLoader) fs() fs.FileSystem {
 	if m.FS == nil {
@@ -99,7 +101,7 @@ func (m *ManifestLoader) Write(filename string, manifest *manifest.Manifest) err
 }
 
 // Read must have already been called and we have a loaded manifest
-func (m *ManifestLoader) Validate(manifest *manifest.Manifest) ManifestErrors {
+func (m *ManifestLoader) Validate(manifest *manifest.Manifest) []ManifestErrors {
 	//TODO: implement this function
 	//// validate Packages
 	//merrors := m.validatePackages(manifest.Packages)

--- a/pkg/kinflate/util/manifestloader_test.go
+++ b/pkg/kinflate/util/manifestloader_test.go
@@ -62,21 +62,21 @@ func TestLoadNotExist(t *testing.T) {
 	fakeFS.Mkdir(".", 0644)
 	fakeFS.Create(badSuffix)
 	loader := kutil.ManifestLoader{FS: fakeFS}
-	_, err := loader.Read("Kube-manifest.yaml")
+	_, err := loader.MakeValidManifestPath("Kube-manifest.yaml")
 	if err == nil {
 		t.Fatalf("expect an error")
 	}
 	if !strings.Contains(err.Error(), "Run `kinflate init` first") {
 		t.Fatalf("expect an error contains %q, but got %v", "does not exist", err)
 	}
-	_, err = loader.Read(".")
+	_, err = loader.MakeValidManifestPath(".")
 	if err == nil {
 		t.Fatalf("expect an error")
 	}
 	if !strings.Contains(err.Error(), "Run `kinflate init` first") {
 		t.Fatalf("expect an error contains %q, but got %v", "does not exist", err)
 	}
-	_, err = loader.Read(badSuffix)
+	_, err = loader.MakeValidManifestPath(badSuffix)
 	if err == nil {
 		t.Fatalf("expect an error")
 	}


### PR DESCRIPTION
This is a partial refactor toward an organization which better supports kinlfate error messages. We recognize that both the Loader and ManifestLoader classes are incoherent, and we intend to address this issue in future PR's. We've included several TODO's.