### PR TITLE
kinflate: removed non-existing resources from manifest file

### DIFF
--- a/pkg/kinflate/commands/addresource_test.go
+++ b/pkg/kinflate/commands/addresource_test.go
@@ -28,10 +28,8 @@ import (
 )
 
 const (
-	// This should be in manifestTemplate.
-	resourceKnownToBeInManifest = "deployment.yaml"
-	resourceFileName            = "myWonderfulResource.yaml"
-	resourceFileContent         = `
+	resourceFileName    = "myWonderfulResource.yaml"
+	resourceFileContent = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 `
@@ -61,15 +59,22 @@ func TestAddResourceHappyPath(t *testing.T) {
 func TestAddResourceAlreadyThere(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	fakeFS := fs.MakeFakeFS()
-	fakeFS.WriteFile(resourceKnownToBeInManifest, []byte(resourceFileContent))
+	fakeFS.WriteFile(resourceFileName, []byte(resourceFileContent))
 	fakeFS.WriteFile(constants.KubeManifestFileName, []byte(manifestTemplate))
+
 	cmd := newCmdAddResource(buf, os.Stderr, fakeFS)
-	args := []string{resourceKnownToBeInManifest}
+	args := []string{resourceFileName}
 	err := cmd.RunE(cmd, args)
+	if err != nil {
+		t.Fatalf("unexpected cmd error: %v", err)
+	}
+
+	// adding an existing resource should return an error
+	err = cmd.RunE(cmd, args)
 	if err == nil {
 		t.Errorf("expected already there problem")
 	}
-	if err.Error() != "resource "+resourceKnownToBeInManifest+" already in manifest" {
+	if err.Error() != "resource "+resourceFileName+" already in manifest" {
 		t.Errorf("unexpected error %v", err)
 	}
 }

--- a/pkg/kinflate/commands/commands.go
+++ b/pkg/kinflate/commands/commands.go
@@ -31,9 +31,9 @@ func NewDefaultCommand() *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "kinflate",
-		Short: "kinflate is a kubernetes cluster configuration utility",
+		Short: "kinflate manages Kubernetes application configuration.",
 		Long: `
-kinflate is a kubernetes cluster configuration utility.
+kinflate manages Kubernetes application configuration.
 
 Find more information at:
 	https://github.com/kubernetes/kubectl/tree/master/cmd/kinflate

--- a/pkg/kinflate/commands/init.go
+++ b/pkg/kinflate/commands/init.go
@@ -40,9 +40,10 @@ objectLabels:
   app: helloworld
 objectAnnotations:
   note: This is an example annotation
-resources:
-- deployment.yaml
-- service.yaml
+# Add Resources to inflate below. List of directories/file-paths to add.
+resources: []
+#- service.yaml
+#- ../some-dir/
 # There could also be configmaps in Base, which would make these overlays
 configmaps: []
 # There could be secrets in Base, if just using a fork/rebase workflow
@@ -62,7 +63,8 @@ func newCmdInit(out, errOut io.Writer, fs fs.FileSystem) *cobra.Command {
 		Short: "Creates a file called \"" + constants.KubeManifestFileName + "\" in the current directory",
 		Long: "Creates a file called \"" +
 			constants.KubeManifestFileName + "\" in the current directory with example values.",
-		Example: `init`,
+		Example:      `init`,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := o.Validate(cmd, args)
 			if err != nil {


### PR DESCRIPTION
`kinflate init` generates a manifest file which contains
non-existent resources in `resources` section. This change
keeps those resources in commented form so that 'kinflate inflate'
doesnt barf at the user.