### PR TITLE
removed '-u' option from install command

### DIFF
--- a/cmd/kinflate/README.md
+++ b/cmd/kinflate/README.md
@@ -8,7 +8,7 @@
 
 <!-- @installKinflate @test -->
 ```shell
-go get -u k8s.io/kubectl/cmd/kinflate
+go get k8s.io/kubectl/cmd/kinflate
 ```
 
 After running the above command, `kinflate` should get installed in your `GOPATH/bin` directory.


### PR DESCRIPTION
'go get' complains if package exists and has been checked out with
different protocol (https/git). This results in tutorial integration
test failures. Disabling the option untill we have a solid solution.