### PR TITLE
Add util functions to read/write manifest file and update sub commands

### DIFF
--- a/pkg/kinflate/commands/addresource.go
+++ b/pkg/kinflate/commands/addresource.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubectl/pkg/kinflate/constants"
-	"k8s.io/kubectl/pkg/kinflate/tree"
 	"k8s.io/kubectl/pkg/kinflate/util/fs"
 )
 
@@ -87,8 +86,12 @@ func (o *addResourceOptions) RunAddResource(out, errOut io.Writer, fsys fs.FileS
 		return err
 	}
 
-	loader := tree.ManifestLoader{FS: fsys}
-	m, err := loader.Read(constants.KubeManifestFileName)
+	mf, err := newManifestFile(constants.KubeManifestFileName, fsys)
+	if err != nil {
+		return err
+	}
+
+	m, err := mf.read()
 	if err != nil {
 		return err
 	}
@@ -99,5 +102,5 @@ func (o *addResourceOptions) RunAddResource(out, errOut io.Writer, fsys fs.FileS
 
 	m.Resources = append(m.Resources, o.resourceFilePath)
 
-	return loader.Write(constants.KubeManifestFileName, m)
+	return mf.write(m)
 }

--- a/pkg/kinflate/commands/configmap.go
+++ b/pkg/kinflate/commands/configmap.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/spf13/cobra"
+
 	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
 	"k8s.io/kubectl/pkg/kinflate/configmapandsecret"
 	"k8s.io/kubectl/pkg/kinflate/constants"
-	"k8s.io/kubectl/pkg/kinflate/tree"
 	"k8s.io/kubectl/pkg/kinflate/util/fs"
-
-	"github.com/spf13/cobra"
 )
 
 func newCmdAddConfigMap(errOut io.Writer, fsys fs.FileSystem) *cobra.Command {
@@ -52,8 +51,12 @@ func newCmdAddConfigMap(errOut io.Writer, fsys fs.FileSystem) *cobra.Command {
 			}
 
 			// Load in the manifest file.
-			loader := tree.ManifestLoader{FS: fsys}
-			m, err := loader.Read(constants.KubeManifestFileName)
+			mf, err := newManifestFile(constants.KubeManifestFileName, fsys)
+			if err != nil {
+				return err
+			}
+
+			m, err := mf.read()
 			if err != nil {
 				return err
 			}
@@ -65,7 +68,7 @@ func newCmdAddConfigMap(errOut io.Writer, fsys fs.FileSystem) *cobra.Command {
 			}
 
 			// Write out the manifest with added configmap.
-			return loader.Write(constants.KubeManifestFileName, m)
+			return mf.write(m)
 		},
 	}
 

--- a/pkg/kinflate/commands/set_name_prefix.go
+++ b/pkg/kinflate/commands/set_name_prefix.go
@@ -17,13 +17,12 @@ limitations under the License.
 package commands
 
 import (
+	"errors"
 	"io"
 
-	"errors"
-
 	"github.com/spf13/cobra"
+
 	"k8s.io/kubectl/pkg/kinflate/constants"
-	"k8s.io/kubectl/pkg/kinflate/tree"
 	"k8s.io/kubectl/pkg/kinflate/util/fs"
 )
 
@@ -78,11 +77,14 @@ func (o *setNamePrefixOptions) Complete(cmd *cobra.Command, args []string) error
 
 // RunSetNamePrefix runs setNamePrefix command (does real work).
 func (o *setNamePrefixOptions) RunSetNamePrefix(out, errOut io.Writer, fsys fs.FileSystem) error {
-	loader := tree.ManifestLoader{FS: fsys}
-	m, err := loader.Read(constants.KubeManifestFileName)
+	mf, err := newManifestFile(constants.KubeManifestFileName, fsys)
+	if err != nil {
+		return err
+	}
+	m, err := mf.read()
 	if err != nil {
 		return err
 	}
 	m.NamePrefix = o.prefix
-	return loader.Write(constants.KubeManifestFileName, m)
+	return mf.write(m)
 }

--- a/pkg/kinflate/commands/util.go
+++ b/pkg/kinflate/commands/util.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
+	"k8s.io/kubectl/pkg/kinflate/constants"
+	interror "k8s.io/kubectl/pkg/kinflate/internal/error"
+	"k8s.io/kubectl/pkg/kinflate/util/fs"
+)
+
+type manifestFile struct {
+	mPath string
+	fsys  fs.FileSystem
+}
+
+func newManifestFile(mPath string, fsys fs.FileSystem) (*manifestFile, error) {
+	mf := &manifestFile{mPath: mPath, fsys: fsys}
+	err := mf.validate()
+	if err != nil {
+		return nil, err
+	}
+	return mf, nil
+}
+
+func (mf *manifestFile) validate() error {
+	f, err := mf.fsys.Stat(mf.mPath)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Manifest (%s) missing\nRun `kinflate init` first", mf.mPath)
+		merr := interror.ManifestError{ManifestFilepath: mf.mPath, ErrorMsg: errorMsg}
+		return merr
+	}
+	if f.IsDir() {
+		mf.mPath = path.Join(mf.mPath, constants.KubeManifestFileName)
+		_, err = mf.fsys.Stat(mf.mPath)
+		if err != nil {
+			errorMsg := fmt.Sprintf("Manifest (%s) missing\nRun `kinflate init` first", mf.mPath)
+			merr := interror.ManifestError{ManifestFilepath: mf.mPath, ErrorMsg: errorMsg}
+			return merr
+		}
+	} else {
+		if !strings.HasSuffix(mf.mPath, constants.KubeManifestFileName) {
+			errorMsg := fmt.Sprintf("Manifest file (%s) should have %s suffix\n", mf.mPath, constants.KubeManifestSuffix)
+			merr := interror.ManifestError{ManifestFilepath: mf.mPath, ErrorMsg: errorMsg}
+			return merr
+		}
+	}
+	return nil
+}
+
+func (mf *manifestFile) read() (*manifest.Manifest, error) {
+	bytes, err := mf.fsys.ReadFile(mf.mPath)
+	if err != nil {
+		return nil, err
+	}
+	var manifest manifest.Manifest
+	err = yaml.Unmarshal(bytes, &manifest)
+	if err != nil {
+		return nil, err
+	}
+	return &manifest, err
+}
+
+func (mf *manifestFile) write(manifest *manifest.Manifest) error {
+	if manifest == nil {
+		return errors.New("util: failed to write passed-in nil manifest")
+	}
+	bytes, err := yaml.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+
+	return mf.fsys.WriteFile(mf.mPath, bytes)
+}

--- a/pkg/kinflate/commands/util_test.go
+++ b/pkg/kinflate/commands/util_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
+	"k8s.io/kubectl/pkg/kinflate/util/fs"
+)
+
+func TestWriteAndRead(t *testing.T) {
+	manifest := &manifest.Manifest{
+		NamePrefix: "prefix",
+	}
+
+	fsys := fs.MakeFakeFS()
+	fsys.Create("Kube-manifest.yaml")
+	mf, err := newManifestFile("Kube-manifest.yaml", fsys)
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+
+	if err := mf.write(manifest); err != nil {
+		t.Fatalf("Couldn't write manifest file: %v\n", err)
+	}
+
+	readManifest, err := mf.read()
+	if err != nil {
+		t.Fatalf("Couldn't read manifest file: %v\n", err)
+	}
+	if !reflect.DeepEqual(manifest, readManifest) {
+		t.Fatal("Read manifest is different from written manifest")
+	}
+}
+
+func TestEmptyFile(t *testing.T) {
+	fsys := fs.MakeFakeFS()
+	_, err := newManifestFile("", fsys)
+	if err == nil {
+		t.Fatalf("Creat manifestFile from empty filename should fail")
+	}
+}
+
+func TestNewNotExist(t *testing.T) {
+	badSuffix := "foo.bar"
+	fakeFS := fs.MakeFakeFS()
+	fakeFS.Mkdir(".", 0644)
+	fakeFS.Create(badSuffix)
+	_, err := newManifestFile("Kube-manifest.yaml", fakeFS)
+	if err == nil {
+		t.Fatalf("expect an error")
+	}
+	if !strings.Contains(err.Error(), "Run `kinflate init` first") {
+		t.Fatalf("expect an error contains %q, but got %v", "does not exist", err)
+	}
+	_, err = newManifestFile("Kube-manifest.yaml", fakeFS)
+	if err == nil {
+		t.Fatalf("expect an error")
+	}
+	if !strings.Contains(err.Error(), "Run `kinflate init` first") {
+		t.Fatalf("expect an error contains %q, but got %v", "does not exist", err)
+	}
+	_, err = newManifestFile(badSuffix, fakeFS)
+	if err == nil {
+		t.Fatalf("expect an error")
+	}
+	if !strings.Contains(err.Error(), "should have .yaml suffix") {
+		t.Fatalf("expect an error contains %q, but got %v", "does not exist", err)
+	}
+}


### PR DESCRIPTION
This change removes all the dependency on package tree from sub commands add resource, add configmap, set nameprefix