### PR TITLE
appending name hash only applies to current layer

### DIFF
--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.diff
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.diff
@@ -26,7 +26,7 @@ diff -u -N /tmp/noop/apps_v1beta2_Deployment_nginx.yaml /tmp/transformed/apps_v1
          org: example.com
          team: foo
      spec:
-@@ -30,5 +33,6 @@
+@@ -30,8 +33,12 @@
          - mountPath: /tmp/ps
            name: nginx-persistent-storage
        volumes:
@@ -34,6 +34,37 @@ diff -u -N /tmp/noop/apps_v1beta2_Deployment_nginx.yaml /tmp/transformed/apps_v1
 +      - gcePersistentDisk:
 +          pdName: nginx-persistent-storage
          name: nginx-persistent-storage
+       - configMap:
++          name: staging-configmap-in-overlay-h4hbb8fckf
++        name: configmap-in-overlay
++      - configMap:
+           name: team-foo-configmap-in-base-72t84tc949
+         name: configmap-in-base
+diff -u -N /tmp/noop/v1_ConfigMap_configmap-in-base.yaml /tmp/transformed/v1_ConfigMap_configmap-in-base.yaml
+--- /tmp/noop/v1_ConfigMap_configmap-in-base.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_configmap-in-base.yaml	YYYY-MM-DD HH:MM:SS
+@@ -8,6 +8,7 @@
+   creationTimestamp: null
+   labels:
+     app: mynginx
++    env: staging
+     org: example.com
+     team: foo
+-  name: team-foo-configmap-in-base-72t84tc949
++  name: staging-team-foo-configmap-in-base-72t84tc949
+diff -u -N /tmp/noop/v1_ConfigMap_configmap-in-overlay.yaml /tmp/transformed/v1_ConfigMap_configmap-in-overlay.yaml
+--- /tmp/noop/v1_ConfigMap_configmap-in-overlay.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_configmap-in-overlay.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,9 @@
++apiVersion: v1
++data:
++  hello: world
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  labels:
++    env: staging
++  name: staging-configmap-in-overlay-h4hbb8fckf
 diff -u -N /tmp/noop/v1_Service_nginx.yaml /tmp/transformed/v1_Service_nginx.yaml
 --- /tmp/noop/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.yaml
@@ -1,4 +1,29 @@
 apiVersion: v1
+data:
+  foo: bar
+kind: ConfigMap
+metadata:
+  annotations:
+    note: This is a test annotation
+  creationTimestamp: null
+  labels:
+    app: mynginx
+    env: staging
+    org: example.com
+    team: foo
+  name: staging-team-foo-configmap-in-base-72t84tc949
+---
+apiVersion: v1
+data:
+  hello: world
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    env: staging
+  name: staging-configmap-in-overlay-h4hbb8fckf
+---
+apiVersion: v1
 kind: Service
 metadata:
   annotations:
@@ -56,3 +81,9 @@ spec:
       - gcePersistentDisk:
           pdName: nginx-persistent-storage
         name: nginx-persistent-storage
+      - configMap:
+          name: staging-configmap-in-overlay-h4hbb8fckf
+        name: configmap-in-overlay
+      - configMap:
+          name: team-foo-configmap-in-base-72t84tc949
+        name: configmap-in-base

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/Kube-manifest.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/Kube-manifest.yaml
@@ -10,3 +10,7 @@ patches:
   - deployment.yaml
 packages:
   - ../package/
+configmaps:
+  - name: configmap-in-overlay
+    literals:
+      - hello=world

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/deployment.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/deployment.yaml
@@ -10,3 +10,6 @@ spec:
         emptyDir: null
         gcePersistentDisk:
           pdName: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-overlay
+        name: configmap-in-overlay

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/Kube-manifest.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/Kube-manifest.yaml
@@ -13,3 +13,7 @@ objectAnnotations:
 resources:
   - deployment.yaml
   - service.yaml
+configmaps:
+  - name: configmap-in-base
+    literals:
+      - foo=bar

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/deployment.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/deployment.yaml
@@ -19,3 +19,6 @@ spec:
       volumes:
       - name: nginx-persistent-storage
         emptyDir: {}
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base


### PR DESCRIPTION
@Liujingfang1 observed a bug the hash can be appended in multiple layers, e.g. `configmap-<hash1>-<hash2>`

The name hash transformer should be only applied to the configmap and secrets generated from the current layer.
