### PR TITLE
Use passed-in context in pluginutils config initializer

### DIFF
--- a/pkg/pluginutils/plugin_client.go
+++ b/pkg/pluginutils/plugin_client.go
@@ -82,7 +82,16 @@ func clientFromConfig(path string) (*restclient.Config, string, error) {
 		return nil, "", fmt.Errorf("the provided credentials %q could not be loaded: %v", path, err)
 	}
 
-	cfg := clientcmd.NewDefaultClientConfig(*credentials, &clientcmd.ConfigOverrides{})
+	overrides := &clientcmd.ConfigOverrides{}
+	var cfg clientcmd.ClientConfig
+	context := os.Getenv("KUBECTL_PLUGINS_GLOBAL_FLAG_CONTEXT")
+	if len(context) > 0 {
+		rules := clientcmd.NewDefaultClientConfigLoadingRules()
+		cfg = clientcmd.NewNonInteractiveClientConfig(*credentials, context, overrides, rules)
+	} else {
+		cfg = clientcmd.NewDefaultClientConfig(*credentials, overrides)
+	}
+
 	config, err := cfg.ClientConfig()
 	if err != nil {
 		return nil, "", fmt.Errorf("the provided credentials %q could not be used: %v", path, err)
@@ -129,11 +138,6 @@ func applyGlobalOptionsToConfig(config *restclient.Config) error {
 
 	cluster := os.Getenv("KUBECTL_PLUGINS_GLOBAL_FLAG_CLUSTER")
 	if len(cluster) > 0 {
-		// TODO(jvallejo): figure out how to override kubeconfig options
-	}
-
-	context := os.Getenv("KUBECTL_PLUGINS_GLOBAL_FLAG_CONTEXT")
-	if len(context) > 0 {
 		// TODO(jvallejo): figure out how to override kubeconfig options
 	}
 

--- a/pkg/pluginutils/plugin_client_test.go
+++ b/pkg/pluginutils/plugin_client_test.go
@@ -42,12 +42,11 @@ var _ = Describe("InitConfig", func() {
 				os.Setenv("KUBECTL_PLUGINS_GLOBAL_FLAG_USERNAME", "date")
 				os.Setenv("KUBECTL_PLUGINS_GLOBAL_FLAG_PASSWORD", "elderberry")
 
-				os.Setenv("KUBECTL_PLUGINS_GLOBAL_FLAG_CLUSTER", "")
+				os.Setenv("KUBECTL_PLUGINS_GLOBAL_FLAG_CONTEXT", "california")
 			})
 			It("overrides the config settings with the passed in settings", func() {
 				config, err := pluginutils.InitConfig()
 				Expect(err).NotTo(HaveOccurred())
-
 				Expect(config.Impersonate.UserName).To(Equal("apple"))
 				Expect(config.Impersonate.Groups).Should(ConsistOf("banana", "cherry"))
 
@@ -61,6 +60,8 @@ var _ = Describe("InitConfig", func() {
 
 				Expect(config.Username).To(Equal("date"))
 				Expect(config.Password).To(Equal("elderberry"))
+
+				Expect(config.Host).To(Equal("https://notrealincalifornia.com:1234"))
 			})
 		})
 	})

--- a/pkg/pluginutils/testdata/config
+++ b/pkg/pluginutils/testdata/config
@@ -4,11 +4,19 @@ clusters:
     certificate-authority:
     server: https://notreal.com:1234
   name: local
+- cluster:
+    certificate-authority:
+    server: https://notrealincalifornia.com:1234
+  name: california
 contexts:
 - context:
     cluster: local
     user: myself
   name: local
+- context:
+    cluster: california
+    user: myself
+  name: california
 current-context: local
 kind: Config
 preferences: {}


### PR DESCRIPTION
This will grab the context out of the config file if one is specified by the KUBECTL_GLOBAL_FLAG_CONTEXT passed in from the plugin framework.

@carolynvs might want to take a look at this.