### PR TITLE
Rename KObject to ResourceCollection

### DIFF
--- a/pkg/kinflate/app/application.go
+++ b/pkg/kinflate/app/application.go
@@ -89,7 +89,7 @@ func (a *applicationImpl) Resources() (types.ResourceCollection, error) {
 	}
 	// Only append hash for generated configmaps and secrets.
 	nht := transformers.NewNameHashTransformer()
-	err = nht.Transform(types.KObject(res))
+	err = nht.Transform(res)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (a *applicationImpl) Resources() (types.ResourceCollection, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = t.Transform(types.KObject(res))
+	err = t.Transform(res)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (a *applicationImpl) subAppResources() (types.ResourceCollection, *interror
 func (a *applicationImpl) getTransformer(patches types.ResourceCollection) (transformers.Transformer, error) {
 	ts := []transformers.Transformer{}
 
-	ot, err := transformers.NewOverlayTransformer(types.KObject(patches))
+	ot, err := transformers.NewOverlayTransformer(patches)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kinflate/commands/diff.go
+++ b/pkg/kinflate/commands/diff.go
@@ -22,12 +22,11 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/kinflate/app"
-	"k8s.io/kubectl/pkg/kinflate/types"
-	"k8s.io/kubectl/pkg/loader"
 
+	"k8s.io/kubectl/pkg/kinflate/app"
 	"k8s.io/kubectl/pkg/kinflate/util"
 	"k8s.io/kubectl/pkg/kinflate/util/fs"
+	"k8s.io/kubectl/pkg/loader"
 	"k8s.io/utils/exec"
 )
 
@@ -109,13 +108,13 @@ func (o *diffOptions) RunDiff(out, errOut io.Writer, fs fs.FileSystem) error {
 		return err
 	}
 
-	transformedDir, err := util.WriteToDir(types.KObject(resources), "transformed", printer)
+	transformedDir, err := util.WriteToDir(resources, "transformed", printer)
 	if err != nil {
 		return err
 	}
 	defer transformedDir.Delete()
 
-	noopDir, err := util.WriteToDir(types.KObject(rawResources), "noop", printer)
+	noopDir, err := util.WriteToDir(rawResources, "noop", printer)
 	if err != nil {
 		return err
 	}

--- a/pkg/kinflate/commands/inflate.go
+++ b/pkg/kinflate/commands/inflate.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/kinflate/types"
 
 	"k8s.io/kubectl/pkg/kinflate/app"
 	kutil "k8s.io/kubectl/pkg/kinflate/util"
@@ -106,7 +105,7 @@ func (o *inflateOptions) RunInflate(out, errOut io.Writer, fs fs.FileSystem) err
 	}
 
 	// Output the objects.
-	res, err := kutil.Encode(types.KObject(allResources))
+	res, err := kutil.Encode(allResources)
 	if err != nil {
 		return err
 	}

--- a/pkg/kinflate/configmapandsecret/configmap_secret.go
+++ b/pkg/kinflate/configmapandsecret/configmap_secret.go
@@ -123,7 +123,7 @@ func makeSecret(secret manifest.SecretGenerator, path string) (*corev1.Secret, e
 	return corev1secret, nil
 }
 
-func populateMap(m types.KObject, obj *unstructured.Unstructured, newName string) error {
+func populateMap(m types.ResourceCollection, obj *unstructured.Unstructured, newName string) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
@@ -140,9 +140,9 @@ func populateMap(m types.KObject, obj *unstructured.Unstructured, newName string
 	return nil
 }
 
-// MakeConfigMapsKObject returns a map of <GVK, oldName> -> unstructured object.
-func MakeConfigMapsKObject(maps []manifest.ConfigMap) (types.KObject, error) {
-	m := types.KObject{}
+// MakeConfigMapsResourceCollection returns a map of <GVK, oldName> -> unstructured object.
+func MakeConfigMapsResourceCollection(maps []manifest.ConfigMap) (types.ResourceCollection, error) {
+	m := types.ResourceCollection{}
 	for _, cm := range maps {
 		unstructuredConfigMap, nameWithHash, err := MakeConfigmapAndGenerateName(cm)
 		if err != nil {
@@ -156,9 +156,9 @@ func MakeConfigMapsKObject(maps []manifest.ConfigMap) (types.KObject, error) {
 	return m, nil
 }
 
-// MakeSecretsKObject returns a map of <GVK, oldName> -> unstructured object.
-func MakeSecretsKObject(secrets []manifest.SecretGenerator, path string) (types.KObject, error) {
-	m := types.KObject{}
+// MakeSecretsResourceCollection returns a map of <GVK, oldName> -> unstructured object.
+func MakeSecretsResourceCollection(secrets []manifest.SecretGenerator, path string) (types.ResourceCollection, error) {
+	m := types.ResourceCollection{}
 	for _, secret := range secrets {
 		unstructuredSecret, nameWithHash, err := MakeSecretAndGenerateName(secret, path)
 		if err != nil {

--- a/pkg/kinflate/transformers/labelsandannotations.go
+++ b/pkg/kinflate/transformers/labelsandannotations.go
@@ -55,7 +55,7 @@ func NewMapTransformer(pc []PathConfig, m map[string]string) (Transformer, error
 
 // Transform apply each <key, value> pair in the mapTransformer to the
 // fields specified in mapTransformer.
-func (o *mapTransformer) Transform(m types.KObject) error {
+func (o *mapTransformer) Transform(m types.ResourceCollection) error {
 	for gvkn := range m {
 		obj := m[gvkn]
 		objMap := obj.UnstructuredContent()

--- a/pkg/kinflate/transformers/labelsandannotations_test.go
+++ b/pkg/kinflate/transformers/labelsandannotations_test.go
@@ -87,8 +87,8 @@ func makeService() *unstructured.Unstructured {
 	}
 }
 
-func makeTestMap() types.KObject {
-	return types.KObject{
+func makeTestMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",
@@ -190,8 +190,8 @@ func makeLabeledService() *unstructured.Unstructured {
 	}
 }
 
-func makeLabeledMap() types.KObject {
-	return types.KObject{
+func makeLabeledMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",
@@ -302,8 +302,8 @@ func makeAnnotatededService() *unstructured.Unstructured {
 	}
 }
 
-func makeAnnotatedMap() types.KObject {
-	return types.KObject{
+func makeAnnotatedMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",

--- a/pkg/kinflate/transformers/multitransformer.go
+++ b/pkg/kinflate/transformers/multitransformer.go
@@ -34,7 +34,7 @@ func NewMultiTransformer(t []Transformer) Transformer {
 }
 
 // Transform prepends the name prefix.
-func (o *multiTransformer) Transform(m types.KObject) error {
+func (o *multiTransformer) Transform(m types.ResourceCollection) error {
 	for _, t := range o.transformers {
 		err := t.Transform(m)
 		if err != nil {

--- a/pkg/kinflate/transformers/namehash.go
+++ b/pkg/kinflate/transformers/namehash.go
@@ -39,7 +39,7 @@ func NewNameHashTransformer() Transformer {
 }
 
 // Transform appends hash to configmaps and secrets.
-func (o *nameHashTransformer) Transform(m types.KObject) error {
+func (o *nameHashTransformer) Transform(m types.ResourceCollection) error {
 	for gvkn, obj := range m {
 		switch {
 		case types.SelectByGVK(gvkn.GVK, &schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}):

--- a/pkg/kinflate/transformers/namehash_test.go
+++ b/pkg/kinflate/transformers/namehash_test.go
@@ -37,8 +37,8 @@ func makeSecret(name string) *unstructured.Unstructured {
 	}
 }
 
-func makeHashTestMap() types.KObject {
-	return types.KObject{
+func makeHashTestMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",
@@ -58,8 +58,8 @@ func makeHashTestMap() types.KObject {
 	}
 }
 
-func makeExpectedHashTestMap() types.KObject {
-	return types.KObject{
+func makeExpectedHashTestMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",

--- a/pkg/kinflate/transformers/namereference.go
+++ b/pkg/kinflate/transformers/namereference.go
@@ -50,7 +50,7 @@ func NewNameReferenceTransformer(pc []referencePathConfig) (Transformer, error) 
 // associated with the key. e.g. if <k, v> is one of the key-value pair in the map,
 // then the old name is k.Name and the new name is v.GetName()
 func (o *nameReferenceTransformer) Transform(
-	m types.KObject) error {
+	m types.ResourceCollection) error {
 	for GVKn := range m {
 		obj := m[GVKn]
 		objMap := obj.UnstructuredContent()
@@ -88,7 +88,7 @@ func (err noMatchingGVKNError) Error() string {
 
 func (o *nameReferenceTransformer) updateNameReference(
 	GVK schema.GroupVersionKind,
-	m types.KObject,
+	m types.ResourceCollection,
 ) func(in interface{}) (interface{}, error) {
 	return func(in interface{}) (interface{}, error) {
 		s, ok := in.(string)

--- a/pkg/kinflate/transformers/namereference_test.go
+++ b/pkg/kinflate/transformers/namereference_test.go
@@ -116,8 +116,8 @@ func makeNameRefDeployment(cmName, secretName string) *unstructured.Unstructured
 	}
 }
 
-func makeNameReferenceTestMap() types.KObject {
-	return types.KObject{
+func makeNameReferenceTestMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",
@@ -133,8 +133,8 @@ func makeNameReferenceTestMap() types.KObject {
 	}
 }
 
-func makeNameReferenceUpdatedTestMap() types.KObject {
-	return types.KObject{
+func makeNameReferenceUpdatedTestMap() types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",

--- a/pkg/kinflate/transformers/nooptransformer.go
+++ b/pkg/kinflate/transformers/nooptransformer.go
@@ -29,6 +29,6 @@ func NewNoOpTransformer() Transformer {
 }
 
 // Transform does nothing.
-func (o *noOpTransformer) Transform(_ types.KObject) error {
+func (o *noOpTransformer) Transform(_ types.ResourceCollection) error {
 	return nil
 }

--- a/pkg/kinflate/transformers/overlay.go
+++ b/pkg/kinflate/transformers/overlay.go
@@ -30,13 +30,13 @@ import (
 
 // overlayTransformer contains a map of overlay objects
 type overlayTransformer struct {
-	overlay types.KObject
+	overlay types.ResourceCollection
 }
 
 var _ Transformer = &overlayTransformer{}
 
 // NewOverlayTransformer constructs a overlayTransformer.
-func NewOverlayTransformer(overlay types.KObject) (Transformer, error) {
+func NewOverlayTransformer(overlay types.ResourceCollection) (Transformer, error) {
 	if len(overlay) == 0 {
 		return NewNoOpTransformer(), nil
 	}
@@ -44,7 +44,7 @@ func NewOverlayTransformer(overlay types.KObject) (Transformer, error) {
 }
 
 // Transform apply the overlay on top of the base resources.
-func (o *overlayTransformer) Transform(baseResourceMap types.KObject) error {
+func (o *overlayTransformer) Transform(baseResourceMap types.ResourceCollection) error {
 	// Strategic merge the resources exist in both base and overlay.
 	for gvkn, overlay := range o.overlay {
 		// Merge overlay with base resource.

--- a/pkg/kinflate/transformers/overlay_test.go
+++ b/pkg/kinflate/transformers/overlay_test.go
@@ -125,8 +125,8 @@ func makeMergedDeployment() *unstructured.Unstructured {
 	}
 }
 
-func makeTestKObject(genDeployment func() *unstructured.Unstructured) types.KObject {
-	return types.KObject{
+func makeTestResourceCollection(genDeployment func() *unstructured.Unstructured) types.ResourceCollection {
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 			Name: "deploy1",
@@ -135,8 +135,8 @@ func makeTestKObject(genDeployment func() *unstructured.Unstructured) types.KObj
 }
 
 func TestOverlayRun(t *testing.T) {
-	base := makeTestKObject(makeBaseDeployment)
-	lt, err := NewOverlayTransformer(makeTestKObject(makeOverlayDeployment))
+	base := makeTestResourceCollection(makeBaseDeployment)
+	lt, err := NewOverlayTransformer(makeTestResourceCollection(makeOverlayDeployment))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestOverlayRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := makeTestKObject(makeMergedDeployment)
+	expected := makeTestResourceCollection(makeMergedDeployment)
 	if !reflect.DeepEqual(base, expected) {
 		err = compareMap(base, expected)
 		t.Fatalf("actual doesn't match expected: %v", err)
@@ -152,7 +152,7 @@ func TestOverlayRun(t *testing.T) {
 }
 
 func TestNoSchemaOverlayRun(t *testing.T) {
-	base := types.KObject{
+	base := types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
 			Name: "my-foo",
@@ -172,7 +172,7 @@ func TestNoSchemaOverlayRun(t *testing.T) {
 			},
 		},
 	}
-	Overlay := types.KObject{
+	Overlay := types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
 			Name: "my-foo",
@@ -192,7 +192,7 @@ func TestNoSchemaOverlayRun(t *testing.T) {
 			},
 		},
 	}
-	expected := types.KObject{
+	expected := types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
 			Name: "my-foo",

--- a/pkg/kinflate/transformers/prefixname.go
+++ b/pkg/kinflate/transformers/prefixname.go
@@ -56,7 +56,7 @@ func NewNamePrefixTransformer(pc []PathConfig, np string) (Transformer, error) {
 }
 
 // Transform prepends the name prefix.
-func (o *namePrefixTransformer) Transform(m types.KObject) error {
+func (o *namePrefixTransformer) Transform(m types.ResourceCollection) error {
 	for gvkn := range m {
 		obj := m[gvkn]
 		objMap := obj.UnstructuredContent()

--- a/pkg/kinflate/transformers/transformer.go
+++ b/pkg/kinflate/transformers/transformer.go
@@ -21,5 +21,5 @@ import "k8s.io/kubectl/pkg/kinflate/types"
 // Transformer can transform objects.
 type Transformer interface {
 	// Transform modifies objects in a map, e.g. add prefixes or additional labels.
-	Transform(m types.KObject) error
+	Transform(m types.ResourceCollection) error
 }

--- a/pkg/kinflate/transformers/util_test.go
+++ b/pkg/kinflate/transformers/util_test.go
@@ -37,10 +37,10 @@ func makeConfigMap(name string) *unstructured.Unstructured {
 	}
 }
 
-func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) types.KObject {
+func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) types.ResourceCollection {
 	cm1 := makeConfigMap(name1InObj)
 	cm2 := makeConfigMap(name2InObj)
-	return types.KObject{
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: name1InGVKN,
@@ -52,7 +52,7 @@ func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) typ
 	}
 }
 
-func compareMap(m1, m2 types.KObject) error {
+func compareMap(m1, m2 types.ResourceCollection) error {
 	if len(m1) != len(m2) {
 		keySet1 := []types.GroupVersionKindName{}
 		keySet2 := []types.GroupVersionKindName{}

--- a/pkg/kinflate/types/types.go
+++ b/pkg/kinflate/types/types.go
@@ -29,7 +29,5 @@ type GroupVersionKindName struct {
 	Name string
 }
 
-// KObject is a map from GroupVersionKindName to unstructured objects
-type KObject map[GroupVersionKindName]*unstructured.Unstructured
-
-type ResourceCollection KObject
+// ResourceCollection is a map from GroupVersionKindName to unstructured objects
+type ResourceCollection map[GroupVersionKindName]*unstructured.Unstructured

--- a/pkg/kinflate/util/util.go
+++ b/pkg/kinflate/util/util.go
@@ -51,17 +51,17 @@ func Decode(in []byte) ([]*unstructured.Unstructured, error) {
 	return objs, nil
 }
 
-// DecodeToKObject decodes a list of objects in byte array format.
+// DecodeToResourceCollection decodes a list of objects in byte array format.
 // Decoded object will be inserted in `into` if it's not nil. Otherwise, it will
 // construct a new map and return it.
-func DecodeToKObject(in []byte, into types.KObject) (types.KObject, error) {
+func DecodeToResourceCollection(in []byte, into types.ResourceCollection) (types.ResourceCollection, error) {
 	objs, err := Decode(in)
 	if err != nil {
 		return nil, err
 	}
 
 	if into == nil {
-		into = types.KObject{}
+		into = types.ResourceCollection{}
 	}
 	for i := range objs {
 		metaAccessor, err := meta.Accessor(objs[i])
@@ -93,7 +93,7 @@ func DecodeToKObject(in []byte, into types.KObject) (types.KObject, error) {
 }
 
 // Encode encodes the map `in` and output the encoded objects separated by `---`.
-func Encode(in types.KObject) ([]byte, error) {
+func Encode(in types.ResourceCollection) ([]byte, error) {
 	gvknList := []types.GroupVersionKindName{}
 	for gvkn := range in {
 		gvknList = append(gvknList, gvkn)
@@ -124,8 +124,8 @@ func Encode(in types.KObject) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// WriteToDir write each object in KObject to a file named with GroupVersionKindName.
-func WriteToDir(in types.KObject, dirName string, printer Printer) (*Directory, error) {
+// WriteToDir write each object in ResourceCollection to a file named with GroupVersionKindName.
+func WriteToDir(in types.ResourceCollection, dirName string, printer Printer) (*Directory, error) {
 	dir, err := CreateDirectory(dirName)
 	if err != nil {
 		return &Directory{}, err

--- a/pkg/kinflate/util/util_test.go
+++ b/pkg/kinflate/util/util_test.go
@@ -49,10 +49,10 @@ func makeConfigMap(name string) *unstructured.Unstructured {
 	}
 }
 
-func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) types.KObject {
+func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) types.ResourceCollection {
 	cm1 := makeConfigMap(name1InObj)
 	cm2 := makeConfigMap(name2InObj)
-	return types.KObject{
+	return types.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: name1InGVKN,
@@ -64,9 +64,9 @@ func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) typ
 	}
 }
 
-func TestDecodeToKObject(t *testing.T) {
+func TestDecodeToResourceCollection(t *testing.T) {
 	expected := makeConfigMaps("cm1", "cm2", "cm1", "cm2")
-	m, err := DecodeToKObject(encoded, nil)
+	m, err := DecodeToResourceCollection(encoded, nil)
 	fmt.Printf("%v\n", m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -86,7 +86,7 @@ func TestEncode(t *testing.T) {
 	}
 }
 
-func compareMap(m1, m2 types.KObject) error {
+func compareMap(m1, m2 types.ResourceCollection) error {
 	if len(m1) != len(m2) {
 		keySet1 := []types.GroupVersionKindName{}
 		keySet2 := []types.GroupVersionKindName{}


### PR DESCRIPTION
There will be another PR to change the related function signature to return `ResourceCollection` instead of `[]*Resource`.