### PR TITLE
cleanup Resouce slice related code

### DIFF
--- a/pkg/kinflate/app/application_test.go
+++ b/pkg/kinflate/app/application_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 	"k8s.io/kubectl/pkg/loader"
 	"k8s.io/kubectl/pkg/loader/loadertest"
@@ -74,36 +75,38 @@ metadata:
 }
 
 func TestResources(t *testing.T) {
-	expected := types.ResourceCollection{
+	expected := resource.ResourceCollection{
 		types.GroupVersionKindName{
 			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 			Name: "dply1",
-		}: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata": map[string]interface{}{
-					"name": "foo-dply1",
-					"labels": map[string]interface{}{
-						"app": "nginx",
-					},
-					"annotations": map[string]interface{}{
-						"note": "This is a test annotation",
-					},
-				},
-				"spec": map[string]interface{}{
-					"selector": map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "foo-dply1",
+						"labels": map[string]interface{}{
 							"app": "nginx",
 						},
+						"annotations": map[string]interface{}{
+							"note": "This is a test annotation",
+						},
 					},
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"annotations": map[string]interface{}{
-								"note": "This is a test annotation",
-							},
-							"labels": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
 								"app": "nginx",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"note": "This is a test annotation",
+								},
+								"labels": map[string]interface{}{
+									"app": "nginx",
+								},
 							},
 						},
 					},
@@ -113,47 +116,51 @@ func TestResources(t *testing.T) {
 		types.GroupVersionKindName{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "literalConfigMap",
-		}: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
-					"name": "foo-literalConfigMap-h25f8c59t4",
-					"labels": map[string]interface{}{
-						"app": "nginx",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "foo-literalConfigMap-h25f8c59t4",
+						"labels": map[string]interface{}{
+							"app": "nginx",
+						},
+						"annotations": map[string]interface{}{
+							"note": "This is a test annotation",
+						},
+						"creationTimestamp": nil,
 					},
-					"annotations": map[string]interface{}{
-						"note": "This is a test annotation",
+					"data": map[string]interface{}{
+						"DB_USERNAME": "admin",
+						"DB_PASSWORD": "somepw",
 					},
-					"creationTimestamp": nil,
-				},
-				"data": map[string]interface{}{
-					"DB_USERNAME": "admin",
-					"DB_PASSWORD": "somepw",
 				},
 			},
 		},
 		types.GroupVersionKindName{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
 			Name: "secret",
-		}: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Secret",
-				"metadata": map[string]interface{}{
-					"name": "foo-secret-2c9kh7fh8t",
-					"labels": map[string]interface{}{
-						"app": "nginx",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name": "foo-secret-2c9kh7fh8t",
+						"labels": map[string]interface{}{
+							"app": "nginx",
+						},
+						"annotations": map[string]interface{}{
+							"note": "This is a test annotation",
+						},
+						"creationTimestamp": nil,
 					},
-					"annotations": map[string]interface{}{
-						"note": "This is a test annotation",
+					"type": string(corev1.SecretTypeOpaque),
+					"data": map[string]interface{}{
+						"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
+						"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 					},
-					"creationTimestamp": nil,
-				},
-				"type": string(corev1.SecretTypeOpaque),
-				"data": map[string]interface{}{
-					"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
-					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			},
 		},
@@ -175,16 +182,18 @@ func TestResources(t *testing.T) {
 }
 
 func TestRawResources(t *testing.T) {
-	expected := types.ResourceCollection{
+	expected := resource.ResourceCollection{
 		types.GroupVersionKindName{
 			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 			Name: "dply1",
-		}: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata": map[string]interface{}{
-					"name": "dply1",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "dply1",
+					},
 				},
 			},
 		},
@@ -204,7 +213,7 @@ func TestRawResources(t *testing.T) {
 	}
 }
 
-func compareMap(m1, m2 types.ResourceCollection) error {
+func compareMap(m1, m2 resource.ResourceCollection) error {
 	if len(m1) != len(m2) {
 		keySet1 := []types.GroupVersionKindName{}
 		keySet2 := []types.GroupVersionKindName{}

--- a/pkg/kinflate/resource/appresource.go
+++ b/pkg/kinflate/resource/appresource.go
@@ -17,37 +17,27 @@ limitations under the License.
 package resource
 
 import (
-	kutil "k8s.io/kubectl/pkg/kinflate/util"
 	"k8s.io/kubectl/pkg/loader"
 )
 
-func resourcesFromPath(loader loader.Loader, path string) ([]*Resource, error) {
+func resourcesFromPath(loader loader.Loader, path string) (ResourceCollection, error) {
 	content, err := loader.Load(path)
 	if err != nil {
 		return nil, err
 	}
 
-	objs, err := kutil.Decode(content)
-	if err != nil {
-		return nil, err
-	}
-
-	var res []*Resource
-	for _, obj := range objs {
-		res = append(res, &Resource{Data: obj})
-	}
-	return res, nil
+	return decodeToResourceCollection(content)
 }
 
 //  NewFromPaths returns a slice of Resources given a resource path slice from manifest file.
-func NewFromPaths(loader loader.Loader, paths []string) ([]*Resource, error) {
-	allResources := []*Resource{}
+func NewFromPaths(loader loader.Loader, paths []string) (ResourceCollection, error) {
+	allResources := []ResourceCollection{}
 	for _, path := range paths {
 		res, err := resourcesFromPath(loader, path)
 		if err != nil {
 			return nil, err
 		}
-		allResources = append(allResources, res...)
+		allResources = append(allResources, res)
 	}
-	return allResources, nil
+	return Merge(allResources...)
 }

--- a/pkg/kinflate/resource/appresource_test.go
+++ b/pkg/kinflate/resource/appresource_test.go
@@ -1,34 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resource
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
-	"reflect"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/kinflate/types"
 	"k8s.io/kubectl/pkg/loader/loadertest"
 )
 
-func makeUnconstructed(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": name,
-			},
-		},
-	}
-}
-
 func TestNewFromPaths(t *testing.T) {
 
-	resourceStr := `apiVersion: v1
+	resourceStr := `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dply1
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dply2
@@ -38,9 +44,35 @@ metadata:
 	if ferr := l.AddFile("/home/seans/project/deployment.yaml", []byte(resourceStr)); ferr != nil {
 		t.Fatalf("Error adding fake file: %v\n", ferr)
 	}
-	expected := []*Resource{
-		{Data: makeUnconstructed("dply1")},
-		{Data: makeUnconstructed("dply2")},
+	expected := ResourceCollection{
+		{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name: "dply1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "dply1",
+					},
+				},
+			},
+		},
+		{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name: "dply2",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "dply2",
+					},
+				},
+			},
+		},
 	}
 
 	resources, _ := NewFromPaths(l, []string{"/home/seans/project/deployment.yaml"})
@@ -48,9 +80,31 @@ metadata:
 		t.Fatalf("%#v should contain 2 appResource, but got %d", resources, len(resources))
 	}
 
-	for i, r := range resources {
-		if !reflect.DeepEqual(r.Data, expected[i].Data) {
-			t.Fatalf("expected %v, but got %v", expected[i].Data, r.Data)
+	if err := compareMap(resources, expected); err != nil {
+		t.Fatalf("actual doesn't match expected: %v", err)
+	}
+}
+
+func compareMap(m1, m2 ResourceCollection) error {
+	if len(m1) != len(m2) {
+		keySet1 := []types.GroupVersionKindName{}
+		keySet2 := []types.GroupVersionKindName{}
+		for GVKn := range m1 {
+			keySet1 = append(keySet1, GVKn)
+		}
+		for GVKn := range m1 {
+			keySet2 = append(keySet2, GVKn)
+		}
+		return fmt.Errorf("maps has different number of entries: %#v doesn't equals %#v", keySet1, keySet2)
+	}
+	for GVKn, obj1 := range m1 {
+		obj2, found := m2[GVKn]
+		if !found {
+			return fmt.Errorf("%#v doesn't exist in %#v", GVKn, m2)
+		}
+		if !reflect.DeepEqual(obj1.Data, obj2.Data) {
+			return fmt.Errorf("%#v doesn't match %#v", obj1.Data, obj2.Data)
 		}
 	}
+	return nil
 }

--- a/pkg/kinflate/resource/configmap.go
+++ b/pkg/kinflate/resource/configmap.go
@@ -131,7 +131,7 @@ func addKV(m map[string]string, kv kvPair) error {
 }
 
 // NewFromConfigMaps returns a Resource slice given a configmap metadata slice from manifest file.
-func NewFromConfigMaps(loader loader.Loader, cmList []manifest.ConfigMap) ([]*Resource, error) {
+func NewFromConfigMaps(loader loader.Loader, cmList []manifest.ConfigMap) (ResourceCollection, error) {
 	allResources := []*Resource{}
 	for _, cm := range cmList {
 		res, err := newFromConfigMap(loader, cm)
@@ -140,5 +140,5 @@ func NewFromConfigMaps(loader loader.Loader, cmList []manifest.ConfigMap) ([]*Re
 		}
 		allResources = append(allResources, res)
 	}
-	return allResources, nil
+	return resourceCollectionFromResources(allResources)
 }

--- a/pkg/kinflate/resource/configmap_test.go
+++ b/pkg/kinflate/resource/configmap_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
 	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/loader/loadertest"
@@ -32,7 +33,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 		input       []manifest.ConfigMap
 		filepath    string
 		content     string
-		expected    []*resource.Resource
+		expected    resource.ResourceCollection
 	}
 
 	l := loadertest.NewFakeLoader("/home/seans/project/")
@@ -49,8 +50,11 @@ func TestNewFromConfigMaps(t *testing.T) {
 			},
 			filepath: "/home/seans/project/app.env",
 			content:  "DB_USERNAME=admin\nDB_PASSWORD=somepw",
-			expected: []*resource.Resource{
+			expected: resource.ResourceCollection{
 				{
+					GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+					Name: "envConfigMap",
+				}: &resource.Resource{
 					Data: &unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": "v1",
@@ -79,8 +83,11 @@ func TestNewFromConfigMaps(t *testing.T) {
 			},
 			filepath: "/home/seans/project/app-init.ini",
 			content:  "FOO=bar\nBAR=baz\n",
-			expected: []*resource.Resource{
+			expected: resource.ResourceCollection{
 				{
+					GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+					Name: "fileConfigMap",
+				}: &resource.Resource{
 					Data: &unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": "v1",
@@ -109,8 +116,11 @@ BAR=baz
 					},
 				},
 			},
-			expected: []*resource.Resource{
+			expected: resource.ResourceCollection{
 				{
+					GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+					Name: "literalConfigMap",
+				}: &resource.Resource{
 					Data: &unstructured.Unstructured{
 						Object: map[string]interface{}{
 							"apiVersion": "v1",

--- a/pkg/kinflate/resource/resource.go
+++ b/pkg/kinflate/resource/resource.go
@@ -19,7 +19,6 @@ package resource
 import (
 	"encoding/json"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/kinflate/types"
@@ -37,13 +36,12 @@ func (r *Resource) GVKN() types.GroupVersionKindName {
 	if r.Data == nil {
 		return emptyZVKN
 	}
-	accessor, err := meta.Accessor(r.Data)
-	if err != nil {
-		return emptyZVKN
-	}
-	gvk := r.Data.GetObjectKind().GroupVersionKind()
-	return types.GroupVersionKindName{GVK: gvk, Name: accessor.GetName()}
+	gvk := r.Data.GroupVersionKind()
+	return types.GroupVersionKindName{GVK: gvk, Name: r.Data.GetName()}
 }
+
+// ResourceCollection is a map from GroupVersionKindName to Resource
+type ResourceCollection map[types.GroupVersionKindName]*Resource
 
 func objectToUnstructured(in runtime.Object) (*unstructured.Unstructured, error) {
 	marshaled, err := json.Marshal(in)

--- a/pkg/kinflate/resource/secret.go
+++ b/pkg/kinflate/resource/secret.go
@@ -70,7 +70,7 @@ func createSecretKey(wd string, command string) ([]byte, error) {
 
 // NewFromSecretGenerators takes a SecretGenerator slice and executes its command in directory p
 // then writes the output to a Resource slice and return it.
-func NewFromSecretGenerators(p string, secretList []manifest.SecretGenerator) ([]*Resource, error) {
+func NewFromSecretGenerators(p string, secretList []manifest.SecretGenerator) (ResourceCollection, error) {
 	allResources := []*Resource{}
 	for _, secret := range secretList {
 		res, err := newFromSecretGenerator(p, secret)
@@ -79,5 +79,5 @@ func NewFromSecretGenerators(p string, secretList []manifest.SecretGenerator) ([
 		}
 		allResources = append(allResources, res)
 	}
-	return allResources, nil
+	return resourceCollectionFromResources(allResources)
 }

--- a/pkg/kinflate/resource/secret_test.go
+++ b/pkg/kinflate/resource/secret_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	manifest "k8s.io/kubectl/pkg/apis/manifest/v1alpha1"
 )
 
@@ -42,22 +43,27 @@ func TestNewFromSecretGenerators(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := []*Resource{
-		{Data: &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Secret",
-				"metadata": map[string]interface{}{
-					"name":              "secret",
-					"creationTimestamp": nil,
-				},
-				"type": string(corev1.SecretTypeOpaque),
-				"data": map[string]interface{}{
-					"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
-					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
+	expected := ResourceCollection{
+		{
+			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
+			Name: "secret",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name":              "secret",
+						"creationTimestamp": nil,
+					},
+					"type": string(corev1.SecretTypeOpaque),
+					"data": map[string]interface{}{
+						"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
+						"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
+					},
 				},
 			},
-		}},
+		},
 	}
 
 	if !reflect.DeepEqual(re, expected) {

--- a/pkg/kinflate/resource/util.go
+++ b/pkg/kinflate/resource/util.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/kubectl/pkg/kinflate/types"
+)
+
+// decode decodes a list of objects in byte array format
+func decode(in []byte) ([]*unstructured.Unstructured, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(in), 1024)
+	objs := []*unstructured.Unstructured{}
+
+	var err error
+	for {
+		var out unstructured.Unstructured
+		err = decoder.Decode(&out)
+		if err != nil {
+			break
+		}
+		objs = append(objs, &out)
+	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return objs, nil
+}
+
+// decodeToResourceCollection decodes a list of objects in byte array format.
+// it will return a ResourceCollection.
+func decodeToResourceCollection(in []byte) (ResourceCollection, error) {
+	objs, err := decode(in)
+	if err != nil {
+		return nil, err
+	}
+
+	into := ResourceCollection{}
+	for i, obj := range objs {
+		gvkn := types.GroupVersionKindName{
+			GVK:  obj.GroupVersionKind(),
+			Name: obj.GetName(),
+		}
+		if _, found := into[gvkn]; found {
+			return into, fmt.Errorf("GroupVersionKindName: %#v already exists in the map", gvkn)
+		}
+		into[gvkn] = &Resource{Data: objs[i]}
+	}
+	return into, nil
+}
+
+func resourceCollectionFromResources(resources []*Resource) (ResourceCollection, error) {
+	out := ResourceCollection{}
+	for _, res := range resources {
+		gvkn := res.GVKN()
+		if _, found := out[gvkn]; found {
+			return nil, fmt.Errorf("duplicated %#v is not allowed", gvkn)
+		}
+		out[gvkn] = res
+	}
+	return out, nil
+}
+
+// Merge will merge all of the entries in the slice of ResourceCollection.
+func Merge(rcs ...ResourceCollection) (ResourceCollection, error) {
+	all := ResourceCollection{}
+	for _, rc := range rcs {
+		for gvkn, obj := range rc {
+			if _, found := all[gvkn]; found {
+				return nil, fmt.Errorf("there is already an entry: %q", gvkn)
+			}
+			all[gvkn] = obj
+		}
+	}
+
+	return all, nil
+}

--- a/pkg/kinflate/resource/util_test.go
+++ b/pkg/kinflate/resource/util_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/kinflate/types"
+)
+
+func TestDecodeToResourceCollection(t *testing.T) {
+	encoded := []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+`)
+	expected := ResourceCollection{
+		{
+			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			Name: "cm1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "cm1",
+					},
+				},
+			},
+		},
+		{
+			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			Name: "cm2",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "cm2",
+					},
+				},
+			},
+		},
+	}
+	m, err := decodeToResourceCollection(encoded)
+	fmt.Printf("%v\n", m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(m, expected) {
+		t.Fatalf("%#v doesn't match expected %#v", m, expected)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	input1 := ResourceCollection{
+		types.GroupVersionKindName{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name: "deploy1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "foo-deploy1",
+					},
+				},
+			},
+		},
+	}
+	input2 := ResourceCollection{
+		types.GroupVersionKindName{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+			Name: "stateful1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name": "bar-stateful",
+					},
+				},
+			},
+		},
+	}
+	input := []ResourceCollection{input1, input2}
+	expected := ResourceCollection{
+		types.GroupVersionKindName{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name: "deploy1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "foo-deploy1",
+					},
+				},
+			},
+		},
+		types.GroupVersionKindName{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+			Name: "stateful1",
+		}: &Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "StatefulSet",
+					"metadata": map[string]interface{}{
+						"name": "bar-stateful",
+					},
+				},
+			},
+		},
+	}
+	merged, err := Merge(input...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("%#v doesn't equal expected %#v", merged, expected)
+	}
+}

--- a/pkg/kinflate/transformers/labelsandannotations.go
+++ b/pkg/kinflate/transformers/labelsandannotations.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 )
 
@@ -55,9 +56,9 @@ func NewMapTransformer(pc []PathConfig, m map[string]string) (Transformer, error
 
 // Transform apply each <key, value> pair in the mapTransformer to the
 // fields specified in mapTransformer.
-func (o *mapTransformer) Transform(m types.ResourceCollection) error {
+func (o *mapTransformer) Transform(m resource.ResourceCollection) error {
 	for gvkn := range m {
-		obj := m[gvkn]
+		obj := m[gvkn].Data
 		objMap := obj.UnstructuredContent()
 		for _, path := range o.pathConfigs {
 			if !types.SelectByGVK(gvkn.GVK, path.GroupVersionKind) {

--- a/pkg/kinflate/transformers/multitransformer.go
+++ b/pkg/kinflate/transformers/multitransformer.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package transformers
 
-import "k8s.io/kubectl/pkg/kinflate/types"
+import "k8s.io/kubectl/pkg/kinflate/resource"
 
 // multiTransformer contains a list of transformers.
 type multiTransformer struct {
@@ -34,7 +34,7 @@ func NewMultiTransformer(t []Transformer) Transformer {
 }
 
 // Transform prepends the name prefix.
-func (o *multiTransformer) Transform(m types.ResourceCollection) error {
+func (o *multiTransformer) Transform(m resource.ResourceCollection) error {
 	for _, t := range o.transformers {
 		err := t.Transform(m)
 		if err != nil {

--- a/pkg/kinflate/transformers/namehash.go
+++ b/pkg/kinflate/transformers/namehash.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/kinflate/hash"
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 )
 
@@ -39,14 +40,14 @@ func NewNameHashTransformer() Transformer {
 }
 
 // Transform appends hash to configmaps and secrets.
-func (o *nameHashTransformer) Transform(m types.ResourceCollection) error {
+func (o *nameHashTransformer) Transform(m resource.ResourceCollection) error {
 	for gvkn, obj := range m {
 		switch {
 		case types.SelectByGVK(gvkn.GVK, &schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}):
-			appendHashForConfigMap(obj)
+			appendHashForConfigMap(obj.Data)
 
 		case types.SelectByGVK(gvkn.GVK, &schema.GroupVersionKind{Version: "v1", Kind: "Secret"}):
-			appendHashForSecret(obj)
+			appendHashForSecret(obj.Data)
 		}
 	}
 	return nil

--- a/pkg/kinflate/transformers/namereference.go
+++ b/pkg/kinflate/transformers/namereference.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 )
 
@@ -50,9 +51,9 @@ func NewNameReferenceTransformer(pc []referencePathConfig) (Transformer, error) 
 // associated with the key. e.g. if <k, v> is one of the key-value pair in the map,
 // then the old name is k.Name and the new name is v.GetName()
 func (o *nameReferenceTransformer) Transform(
-	m types.ResourceCollection) error {
+	m resource.ResourceCollection) error {
 	for GVKn := range m {
-		obj := m[GVKn]
+		obj := m[GVKn].Data
 		objMap := obj.UnstructuredContent()
 		for _, referencePathConfig := range o.pathConfigs {
 			for _, path := range referencePathConfig.pathConfigs {
@@ -88,7 +89,7 @@ func (err noMatchingGVKNError) Error() string {
 
 func (o *nameReferenceTransformer) updateNameReference(
 	GVK schema.GroupVersionKind,
-	m types.ResourceCollection,
+	m resource.ResourceCollection,
 ) func(in interface{}) (interface{}, error) {
 	return func(in interface{}) (interface{}, error) {
 		s, ok := in.(string)
@@ -101,7 +102,7 @@ func (o *nameReferenceTransformer) updateNameReference(
 				continue
 			}
 			if GVKn.Name == s {
-				return obj.GetName(), nil
+				return obj.Data.GetName(), nil
 			}
 		}
 		return in, nil

--- a/pkg/kinflate/transformers/namereference_test.go
+++ b/pkg/kinflate/transformers/namereference_test.go
@@ -22,91 +22,102 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubectl/pkg/kinflate/types"
+	"k8s.io/kubectl/pkg/kinflate/resource"
 )
 
-func makeReferencedConfigMap() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
-				"name": "someprefix-cm1-somehash",
+func TestNameReferenceRun(t *testing.T) {
+	m := resource.ResourceCollection{
+		{
+			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			Name: "cm1",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "someprefix-cm1-somehash",
+					},
+				},
 			},
 		},
-	}
-}
-
-func makeReferencedSecret() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name": "someprefix-secret1-somehash",
+		{
+			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
+			Name: "secret1",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name": "someprefix-secret1-somehash",
+					},
+				},
 			},
 		},
-	}
-}
-
-func makeNameRefDeployment(cmName, secretName string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"group":      "apps",
-			"apiVersion": "v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
+		{
+			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Name: "deploy1",
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"group":      "apps",
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deploy1",
+					},
 					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:1.7.9",
-								"env": []interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
 									map[string]interface{}{
-										"name": "CM_FOO",
-										"valueFrom": map[string]interface{}{
-											"configMapKeyRef": map[string]interface{}{
-												"name": cmName,
-												"key":  "somekey",
+										"name":  "nginx",
+										"image": "nginx:1.7.9",
+										"env": []interface{}{
+											map[string]interface{}{
+												"name": "CM_FOO",
+												"valueFrom": map[string]interface{}{
+													"configMapKeyRef": map[string]interface{}{
+														"name": "cm1",
+														"key":  "somekey",
+													},
+												},
+											},
+											map[string]interface{}{
+												"name": "SECRET_FOO",
+												"valueFrom": map[string]interface{}{
+													"secretKeyRef": map[string]interface{}{
+														"name": "secret1",
+														"key":  "somekey",
+													},
+												},
 											},
 										},
-									},
-									map[string]interface{}{
-										"name": "SECRET_FOO",
-										"valueFrom": map[string]interface{}{
-											"secretKeyRef": map[string]interface{}{
-												"name": secretName,
-												"key":  "somekey",
+										"envFrom": []interface{}{
+											map[string]interface{}{
+												"configMapRef": map[string]interface{}{
+													"name": "cm1",
+													"key":  "somekey",
+												},
+											},
+											map[string]interface{}{
+												"secretRef": map[string]interface{}{
+													"name": "secret1",
+													"key":  "somekey",
+												},
 											},
 										},
 									},
 								},
-								"envFrom": []interface{}{
-									map[string]interface{}{
-										"configMapRef": map[string]interface{}{
-											"name": cmName,
-											"key":  "somekey",
-										},
+								"volumes": map[string]interface{}{
+									"configMap": map[string]interface{}{
+										"name": "cm1",
 									},
-									map[string]interface{}{
-										"secretRef": map[string]interface{}{
-											"name": secretName,
-											"key":  "somekey",
-										},
+									"secret": map[string]interface{}{
+										"secretName": "secret1",
 									},
 								},
-							},
-						},
-						"volumes": map[string]interface{}{
-							"configMap": map[string]interface{}{
-								"name": cmName,
-							},
-							"secret": map[string]interface{}{
-								"secretName": secretName,
 							},
 						},
 					},
@@ -114,50 +125,112 @@ func makeNameRefDeployment(cmName, secretName string) *unstructured.Unstructured
 			},
 		},
 	}
-}
 
-func makeNameReferenceTestMap() types.ResourceCollection {
-	return types.ResourceCollection{
+	expected := resource.ResourceCollection{
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
 			Name: "cm1",
-		}: makeReferencedConfigMap(),
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name": "someprefix-cm1-somehash",
+					},
+				},
+			},
+		},
 		{
 			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
 			Name: "secret1",
-		}: makeReferencedSecret(),
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name": "someprefix-secret1-somehash",
+					},
+				},
+			},
+		},
 		{
 			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 			Name: "deploy1",
-		}: makeNameRefDeployment("cm1", "secret1"),
+		}: &resource.Resource{
+			Data: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"group":      "apps",
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name": "deploy1",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "nginx",
+										"image": "nginx:1.7.9",
+										"env": []interface{}{
+											map[string]interface{}{
+												"name": "CM_FOO",
+												"valueFrom": map[string]interface{}{
+													"configMapKeyRef": map[string]interface{}{
+														"name": "someprefix-cm1-somehash",
+														"key":  "somekey",
+													},
+												},
+											},
+											map[string]interface{}{
+												"name": "SECRET_FOO",
+												"valueFrom": map[string]interface{}{
+													"secretKeyRef": map[string]interface{}{
+														"name": "someprefix-secret1-somehash",
+														"key":  "somekey",
+													},
+												},
+											},
+										},
+										"envFrom": []interface{}{
+											map[string]interface{}{
+												"configMapRef": map[string]interface{}{
+													"name": "someprefix-cm1-somehash",
+													"key":  "somekey",
+												},
+											},
+											map[string]interface{}{
+												"secretRef": map[string]interface{}{
+													"name": "someprefix-secret1-somehash",
+													"key":  "somekey",
+												},
+											},
+										},
+									},
+								},
+								"volumes": map[string]interface{}{
+									"configMap": map[string]interface{}{
+										"name": "someprefix-cm1-somehash",
+									},
+									"secret": map[string]interface{}{
+										"secretName": "someprefix-secret1-somehash",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
-}
 
-func makeNameReferenceUpdatedTestMap() types.ResourceCollection {
-	return types.ResourceCollection{
-		{
-			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-			Name: "cm1",
-		}: makeReferencedConfigMap(),
-		{
-			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
-			Name: "secret1",
-		}: makeReferencedSecret(),
-		{
-			GVK:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
-			Name: "deploy1",
-		}: makeNameRefDeployment("someprefix-cm1-somehash", "someprefix-secret1-somehash"),
-	}
-}
-
-func TestNameReferenceRun(t *testing.T) {
-	m := makeNameReferenceTestMap()
 	nrt, err := NewDefaultingNameReferenceTransformer()
 	err = nrt.Transform(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := makeNameReferenceUpdatedTestMap()
 	if !reflect.DeepEqual(m, expected) {
 		err = compareMap(m, expected)
 		t.Fatalf("actual doesn't match expected: %v", err)

--- a/pkg/kinflate/transformers/nooptransformer.go
+++ b/pkg/kinflate/transformers/nooptransformer.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package transformers
 
-import "k8s.io/kubectl/pkg/kinflate/types"
+import "k8s.io/kubectl/pkg/kinflate/resource"
 
 // noOpTransformer contains a no-op transformer.
 type noOpTransformer struct{}
@@ -29,6 +29,6 @@ func NewNoOpTransformer() Transformer {
 }
 
 // Transform does nothing.
-func (o *noOpTransformer) Transform(_ types.ResourceCollection) error {
+func (o *noOpTransformer) Transform(_ resource.ResourceCollection) error {
 	return nil
 }

--- a/pkg/kinflate/transformers/prefixname.go
+++ b/pkg/kinflate/transformers/prefixname.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 )
 
@@ -56,9 +57,9 @@ func NewNamePrefixTransformer(pc []PathConfig, np string) (Transformer, error) {
 }
 
 // Transform prepends the name prefix.
-func (o *namePrefixTransformer) Transform(m types.ResourceCollection) error {
+func (o *namePrefixTransformer) Transform(m resource.ResourceCollection) error {
 	for gvkn := range m {
-		obj := m[gvkn]
+		obj := m[gvkn].Data
 		objMap := obj.UnstructuredContent()
 		for _, path := range o.pathConfigs {
 			if !types.SelectByGVK(gvkn.GVK, path.GroupVersionKind) {

--- a/pkg/kinflate/transformers/transformer.go
+++ b/pkg/kinflate/transformers/transformer.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 package transformers
 
-import "k8s.io/kubectl/pkg/kinflate/types"
+import "k8s.io/kubectl/pkg/kinflate/resource"
 
 // Transformer can transform objects.
 type Transformer interface {
 	// Transform modifies objects in a map, e.g. add prefixes or additional labels.
-	Transform(m types.ResourceCollection) error
+	Transform(m resource.ResourceCollection) error
 }

--- a/pkg/kinflate/transformers/util_test.go
+++ b/pkg/kinflate/transformers/util_test.go
@@ -20,39 +20,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/kinflate/resource"
 	"k8s.io/kubectl/pkg/kinflate/types"
 )
 
-func makeConfigMap(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
-				"name": name,
-			},
-		},
-	}
-}
-
-func makeConfigMaps(name1InGVKN, name2InGVKN, name1InObj, name2InObj string) types.ResourceCollection {
-	cm1 := makeConfigMap(name1InObj)
-	cm2 := makeConfigMap(name2InObj)
-	return types.ResourceCollection{
-		{
-			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-			Name: name1InGVKN,
-		}: cm1,
-		{
-			GVK:  schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-			Name: name2InGVKN,
-		}: cm2,
-	}
-}
-
-func compareMap(m1, m2 types.ResourceCollection) error {
+func compareMap(m1, m2 resource.ResourceCollection) error {
 	if len(m1) != len(m2) {
 		keySet1 := []types.GroupVersionKindName{}
 		keySet2 := []types.GroupVersionKindName{}
@@ -69,8 +41,8 @@ func compareMap(m1, m2 types.ResourceCollection) error {
 		if !found {
 			return fmt.Errorf("%#v doesn't exist in %#v", GVKn, m2)
 		}
-		if !reflect.DeepEqual(obj1, obj2) {
-			return fmt.Errorf("%#v doesn't match %#v", obj1, obj2)
+		if !reflect.DeepEqual(obj1.Data, obj2.Data) {
+			return fmt.Errorf("%#v doesn't match %#v", obj1.Data, obj2.Data)
 		}
 	}
 	return nil

--- a/pkg/kinflate/types/types.go
+++ b/pkg/kinflate/types/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package types
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -28,6 +27,3 @@ type GroupVersionKindName struct {
 	// original name of the resource before transformation.
 	Name string
 }
-
-// ResourceCollection is a map from GroupVersionKindName to unstructured objects
-type ResourceCollection map[GroupVersionKindName]*unstructured.Unstructured

--- a/pkg/kinflate/types/util.go
+++ b/pkg/kinflate/types/util.go
@@ -17,10 +17,8 @@ limitations under the License.
 package types
 
 import (
-	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -58,16 +56,4 @@ func SelectByGVK(in schema.GroupVersionKind, selector *schema.GroupVersionKind) 
 		}
 	}
 	return true
-}
-
-// Merge will merge all the entries in m2 to m1.
-func Merge(m1, m2 map[GroupVersionKindName]*unstructured.Unstructured,
-) error {
-	for gvkn, obj := range m2 {
-		if _, found := m1[gvkn]; found {
-			return fmt.Errorf("there is already an entry: %q", gvkn)
-		}
-		m1[gvkn] = obj
-	}
-	return nil
 }


### PR DESCRIPTION
Change function signature to return ResourceCollection instead of []*Resource.
Cleanup tests and embed test data according the tott article `remove logic from the test`.
Moved ResourceCollection to resource pkg.

Most of this PR is mechanical change, nothing very interesting.