### PR TITLE
Add different behavior for secretGenerator in overlay

### DIFF
--- a/pkg/apis/manifest/v1alpha1/types.go
+++ b/pkg/apis/manifest/v1alpha1/types.go
@@ -149,6 +149,12 @@ type SecretGenerator struct {
 	// hash(content of secret).
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
+	// Behavior of secretGenerator, must be one of create, merge and replace
+	// 'create': create a new one;
+	// 'replace': replace the existing one;
+	// 'merge': merge the existing one.
+	Behavior string `json:"behavior,omitempty" yaml:"behavior,omitempty"`
+
 	// Type of the secret.
 	//
 	// This is the same field as the secret type field in v1/Secret:

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.diff
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.diff
@@ -82,6 +82,28 @@ diff -u -N /tmp/noop/v1_ConfigMap_configmap-in-overlay.yaml /tmp/transformed/v1_
 +    env: staging
 +    team: override-foo
 +  name: staging-configmap-in-overlay-k7cbc75tg8
+diff -u -N /tmp/noop/v1_Secret_secret-in-base.yaml /tmp/transformed/v1_Secret_secret-in-base.yaml
+--- /tmp/noop/v1_Secret_secret-in-base.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_secret-in-base.yaml	YYYY-MM-DD HH:MM:SS
+@@ -1,6 +1,7 @@
+ apiVersion: v1
+ data:
+   password: c29tZXB3
++  proxy: aGFwcm94eQ==
+   username: YWRtaW4=
+ kind: Secret
+ metadata:
+@@ -9,7 +10,8 @@
+   creationTimestamp: null
+   labels:
+     app: mynginx
++    env: staging
+     org: example.com
+-    team: foo
+-  name: team-foo-secret-in-base-tkm7hhtf8d
++    team: override-foo
++  name: staging-team-foo-secret-in-base-c8db7gk2m2
+ type: Opaque
 diff -u -N /tmp/noop/v1_Service_nginx.yaml /tmp/transformed/v1_Service_nginx.yaml
 --- /tmp/noop/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/expected.yaml
@@ -25,6 +25,24 @@ metadata:
   name: staging-configmap-in-overlay-k7cbc75tg8
 ---
 apiVersion: v1
+data:
+  password: c29tZXB3
+  proxy: aGFwcm94eQ==
+  username: YWRtaW4=
+kind: Secret
+metadata:
+  annotations:
+    note: This is a test annotation
+  creationTimestamp: null
+  labels:
+    app: mynginx
+    env: staging
+    org: example.com
+    team: override-foo
+  name: staging-team-foo-secret-in-base-c8db7gk2m2
+type: Opaque
+---
+apiVersion: v1
 kind: Service
 metadata:
   annotations:

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/Kube-manifest.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/overlay/Kube-manifest.yaml
@@ -18,3 +18,8 @@ configmaps:
     behavior: replace
     literals:
       - foo=override-bar
+secretGenerators:
+- name: secret-in-base
+  behavior: merge
+  commands:
+    proxy: "printf haproxy"

--- a/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/Kube-manifest.yaml
+++ b/pkg/kinflate/commands/testdata/testcase-single-overlay/in/package/Kube-manifest.yaml
@@ -16,3 +16,8 @@ configmaps:
   - name: configmap-in-base
     literals:
       - foo=bar
+secretGenerators:
+- name: secret-in-base
+  commands:
+    username: "printf admin"
+    password: "printf somepw"

--- a/pkg/kinflate/resource/secret.go
+++ b/pkg/kinflate/resource/secret.go
@@ -52,7 +52,7 @@ func newFromSecretGenerator(p string, s manifest.SecretGenerator) (*Resource, er
 		return nil, err
 	}
 
-	return &Resource{Data: obj}, nil
+	return &Resource{Data: obj, Behavior: s.Behavior}, nil
 }
 
 func createSecretKey(wd string, command string) ([]byte, error) {


### PR DESCRIPTION
Add `Behavior` to `SecretGenerator`
Add test in `kinflate inflate` and `kinflate diff`

Since the logic is already handled in #373 , when we add `Behavior` for SecretGenerator, it automatically works.