### PR TITLE
kinflate: add build automation

### DIFF
--- a/cmd/kinflate/build/README.md
+++ b/cmd/kinflate/build/README.md
@@ -1,0 +1,16 @@
+## Steps to run build locally
+
+Install container-builder-local from github and define GOOS, GOARCH, OUTPUT env
+variables and run following command
+
+```sh
+container-builder-local --config=cmd/kinflate/build/cloudbuild_local.yaml --dryrun=false --substitutions=_GOOS=$GOOS,_GOARCH=$GOARCH --write-workspace=$OUTPUT .
+```
+
+## Steps to submit build to Google container builder
+
+You need to be at the repo level to be able to run the following command
+
+```
+gcloud container builds submit . --config=cmd/kinflate/build/cloudbuild.yaml --substitutions=_GOOS=$GOOS,_GOARCH=$GOARCH
+```

--- a/cmd/kinflate/build/build.sh
+++ b/cmd/kinflate/build/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+#  Copyright 2018 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+set -x
+
+# Google Container Builder automatically checks out all the code under the /workspace directory,
+# but we actually want it to under the correct expected package in the GOPATH (/go)
+# - Create the directory to host the code that matches the expected GOPATH package locations
+# - Use /go as the default GOPATH because this is what the image uses
+# - Link our current directory (containing the source code) to the package location in the GOPATH
+export PKG=k8s.io
+export REPO=kubectl
+export CMD=kinflate
+
+mkdir -p /go/src/$PKG
+ln -s $(pwd) /go/src/$PKG/$REPO
+
+# Create the output directory for the binaries we will build
+# Make sure CGO is 0 so the binaries are statically compiled and linux which is necessary for cross compiling go
+export CGO=0
+export DEST=/workspace/_output/$CMD/bin
+mkdir -p $DEST || echo ""
+
+go build -o $DEST/$CMD $PKG/$REPO/cmd/$CMD
+
+# Explicitly set the values of the variables in package "X" using ldflag so that they are statically compiled into
+# the "version" command
+export GITCOMMIT=$(git rev-parse HEAD)
+export BUILDDATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+export X=$PKG/$REPO/cmd/$CMD/version
+go build -o $DEST/$CMD \
+ -ldflags "-X $X.kinflateVersion=$TAG -X $X.goos=$GOOS -X $X.goarch=$GOARCH -X $X.gitCommit=$GITCOMMIT -X $X.buildDate=$BUILDDATE" \
+	$PKG/$REPO/cmd/$CMD
+
+# Generate the tar archive
+cd /workspace/_output/
+tar -czvf /workspace/$CMD-$VERSION-$GOOS-$GOARCH.tar.gz $CMD

--- a/cmd/kinflate/build/cloudbuild.yaml
+++ b/cmd/kinflate/build/cloudbuild.yaml
@@ -1,0 +1,30 @@
+#  Copyright 2018 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# TODO(droot): add instructions for running in production.
+steps:
+- name: "ubuntu"
+  args: ["mkdir", "-p", "/workspace/_output"]
+- name: "golang:1.10-stretch"
+  args: ["bash", "cmd/kinflate/build/build.sh"]
+  env:
+  - 'GOOS=${_GOOS}'
+  - 'GOARCH=${_GOARCH}'
+  - 'VERSION=${TAG_NAME}'
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-h', 'Content-Type:application/gzip', 'cp', '-a', 'public-read', 'kinflate-${TAG_NAME}-${_GOOS}-${_GOARCH}.tar.gz', 'gs://kinflate-release/kinflate-${TAG_NAME}-${_GOOS}-${_GOARCH}.tar.gz']
+  env:
+  - 'GOOS=${_GOOS}'
+  - 'GOARCH=${_GOARCH}'
+  - 'VERSION=${TAG_NAME}'

--- a/cmd/kinflate/build/cloudbuild_local.yaml
+++ b/cmd/kinflate/build/cloudbuild_local.yaml
@@ -1,0 +1,31 @@
+#  Copyright 2018 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Instructions to run locally:
+# Download google container builder: https://github.com/kubernetes-sigs/container-builder-local
+# Set you GOOS and GOARCH vars to match your system
+# Set OUTPUT to the location to write the directory containing the tar.gz
+# $ container-builder-local --config=build/cloudbuild_local.yaml --dryrun=false \
+#   --substitutions=_GOOS=$GOOS,_GOARCH=$GOARCH --write-workspace=$OUTPUT .
+# Release tar will be in $OUTPUT
+
+steps:
+- name: "ubuntu"
+  args: ["mkdir", "-p", "/workspace/_output"]
+- name: "golang:1.10-stretch"
+  args: ["bash", "cmd/kinflate/build/build.sh"]
+  env:
+  - 'GOOS=${_GOOS}'
+  - 'GOARCH=${_GOARCH}'
+  - 'VERSION=${TAG_NAME}'


### PR DESCRIPTION
Highlights:
- Adds a build script to generate the archive for Kinflate
- Adds configs for Google Container Builder to generate the build locally or in Google container builder

I have tested the build triggers with my fork.