### PR TITLE
Remove the -f option of inflate

### DIFF
--- a/cmd/kinflate/demo/helloWorldDetailed/customize.md
+++ b/cmd/kinflate/demo/helloWorldDetailed/customize.md
@@ -12,7 +12,7 @@ sed -i 's/app: hello/app: my-hello/' \
 See the effect:
 <!-- @manifest @test -->
 ```
-kinflate inflate -f $BASE | grep -C 3 app:
+kinflate inflate $BASE | grep -C 3 app:
 ```
 
 __Next:__ [Overlays](overlays)

--- a/cmd/kinflate/demo/helloWorldDetailed/manifest.md
+++ b/cmd/kinflate/demo/helloWorldDetailed/manifest.md
@@ -13,7 +13,7 @@ to `stdout`:
 
 <!-- @manifest @test -->
 ```
-kinflate inflate -f $BASE
+kinflate inflate $BASE
 ```
 
 __Next:__ [Customize it](customize.md)

--- a/cmd/kinflate/demo/helloWorldDetailed/overlays/deploy.md
+++ b/cmd/kinflate/demo/helloWorldDetailed/overlays/deploy.md
@@ -4,23 +4,23 @@ The individual resource sets are:
 
 <!-- @runKinflateStaging @test -->
 ```
-kinflate inflate -f $OVERLAYS/staging
+kinflate inflate $OVERLAYS/staging
 ```
 
 <!-- @runKinflateProduction @test -->
 ```
-kinflate inflate -f $OVERLAYS/production
+kinflate inflate $OVERLAYS/production
 ```
 
 To deploy, pipe the above commands to kubectl apply:
 
 > ```
-> kinflate inflate -f $OVERLAYS/staging |\
+> kinflate inflate $OVERLAYS/staging |\
 >     kubectl apply -f -
 > ```
 
 > ```
-> kinflate inflate -f $OVERLAYS/production |\
+> kinflate inflate $OVERLAYS/production |\
 >    kubectl apply -f -
 > ```
 

--- a/cmd/kinflate/demo/helloWorldOnePager.md
+++ b/cmd/kinflate/demo/helloWorldOnePager.md
@@ -44,14 +44,14 @@ Confirm that the prefix appears in the output:
 
 <!-- @confirmResourceNames @test -->
 ```
-kinflate inflate -f . | grep --context=3 acme-
+kinflate inflate | grep --context=3 acme-
 ```
 
 Optionally apply the modified configuration to a cluster
 
 <!-- @applyToCluster -->
 ```
-kinflate inflate -f . | kubectl apply -f -
+kinflate inflate | kubectl apply -f -
 ```
 
 This fork of [example-hello] could be commited to a

--- a/cmd/kinflate/demo/mySql.md
+++ b/cmd/kinflate/demo/mySql.md
@@ -128,7 +128,7 @@ resource names.
 
 <!-- @genNamePrefixConfig @test -->
 ```
-kinflate inflate -f $DEMO_HOME
+kinflate inflate $DEMO_HOME
 ```
 
 The output should contain:
@@ -176,7 +176,7 @@ sed -i 's/app: helloworld/app: prod/' \
     $DEMO_HOME/Kube-manifest.yaml
 ```
 
-At this point, running `kinflate inflate -f .` will
+At this point, running `kinflate inflate` will
 generate MySQL configs with name-prefix 'prod-' and
 labels `env:prod`.
 
@@ -235,5 +235,5 @@ create the production environment.
 
 <!-- @finalInflation @test -->
 ```
-kinflate inflate -f $DEMO_HOME  # | kubectl apply -f -
+kinflate inflate $DEMO_HOME  # | kubectl apply -f -
 ```

--- a/pkg/kinflate/commands/inflate_test.go
+++ b/pkg/kinflate/commands/inflate_test.go
@@ -39,6 +39,40 @@ type InflateTestCase struct {
 	ExpectedStdout string `yaml:"expectedStdout"`
 }
 
+func TestInflateValidate(t *testing.T) {
+	var cases = []struct {
+		name  string
+		args  []string
+		path  string
+		erMsg string
+	}{
+		{"noargs", []string{}, "./", ""},
+		{"file", []string{"beans"}, "beans", ""},
+		{"path", []string{"a/b/c"}, "a/b/c", ""},
+		{"path", []string{"too", "many"}, "", "specify one path to manifest"},
+	}
+	for _, mycase := range cases {
+		opts := inflateOptions{}
+		e := opts.Validate(mycase.args)
+		if len(mycase.erMsg) > 0 {
+			if e == nil {
+				t.Errorf("%s: Expected an error %v", mycase.name, mycase.erMsg)
+			}
+			if e.Error() != mycase.erMsg {
+				t.Errorf("%s: Expected error %s, but got %v", mycase.name, mycase.erMsg, e)
+			}
+			continue
+		}
+		if e != nil {
+			t.Errorf("%s: unknown error %v", mycase.name, e)
+			continue
+		}
+		if opts.manifestPath != mycase.path {
+			t.Errorf("%s: expected path '%s', got '%s'", mycase.name, mycase.path, opts.manifestPath)
+		}
+	}
+}
+
 func TestInflate(t *testing.T) {
 	const updateEnvVar = "UPDATE_KINFLATE_EXPECTED_DATA"
 	updateKinflateExpected := os.Getenv(updateEnvVar) == "true"


### PR DESCRIPTION
The manifest path is now just the first arg after the command.
If no arg specified, the current working directory is assumed.
