### PR TITLE
Add logging for replacing and merging configmap and secrets

### DIFF
--- a/pkg/kinflate/resource/util.go
+++ b/pkg/kinflate/resource/util.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/kubectl/pkg/kinflate/constants"
@@ -107,11 +109,14 @@ func MergeWithOverride(rcs ...ResourceCollection) (ResourceCollection, error) {
 				case "", constants.CreateBehavior:
 					return nil, fmt.Errorf("Create an existing gvkn %#v is not allowed", gvkn)
 				case constants.ReplaceBehavior:
+					glog.V(4).Infof("Replace object %v by %v", all[gvkn].Data.Object, obj.Data.Object)
 					obj.replace(all[gvkn])
 					all[gvkn] = obj
 				case constants.MergeBehavior:
+					glog.V(4).Infof("Merge object %v with %v", all[gvkn].Data.Object, obj.Data.Object)
 					obj.merge(all[gvkn])
 					all[gvkn] = obj
+					glog.V(4).Infof("The merged object is %v", all[gvkn].Data.Object)
 				default:
 					return nil, fmt.Errorf("The behavior of %#v must be one of merge and replace since it already exists in the base", gvkn)
 				}


### PR DESCRIPTION
Tested locally with ` kinflate inflate --alsologtostderr  --v 4 instances/staging`. 
Here is the output
``` 
I0405 16:07:23.576661  257572 decoder.go:224] decoding stream as YAML
I0405 16:07:23.577546  257572 decoder.go:224] decoding stream as YAML
I0405 16:07:23.578280  257572 util.go:116] Merge object map[kind:ConfigMap apiVersion:v1 metadata:map[name:my-demo-configmap creationTimestamp:<nil>] data:map[application.properties:app.name=Kinflate Demo for a Spring Boot application
]] with map[kind:ConfigMap apiVersion:v1 metadata:map[name:demo-configmap creationTimestamp:<nil>] data:map[application.properties:app.name=Staging Kinflate Demo
spring.jpa.hibernate.ddl-auto=update
spring.datasource.url=jdbc:mysql://35.184.58.94:3306/db_example
spring.datasource.username=roott
spring.datasource.password=admin
 foo:bar staging:]]
I0405 16:07:23.578347  257572 util.go:119] The merged object is map[kind:ConfigMap apiVersion:v1 metadata:map[creationTimestamp:<nil> labels:map[] annotations:map[] name:my-demo-configmap] data:map[application.properties:app.name=Staging Kinflate Demo
spring.jpa.hibernate.ddl-auto=update
spring.datasource.url=jdbc:mysql://35.184.58.94:3306/db_example
spring.datasource.username=roott
spring.datasource.password=admin
 foo:bar staging:]]
```