### PR TITLE
structure for manifest documentation

### DIFF
--- a/cmd/kinflate/Makefile
+++ b/cmd/kinflate/Makefile
@@ -1,0 +1,25 @@
+SHELL := /bin/bash -euo pipefail
+
+config_file_name = Kube-manifest.yaml
+example_config = docs/$(config_file_name)
+
+.PHONY: all
+all: docs
+
+# In a branch, run 'make docs' to update docs with
+# generated code, then merge it to master.
+docs: $(example_config)
+
+# Use kinflate to create the standard kinflate configuration
+# file that appears in the website's documentation.
+$(example_config): /tmp/bin/kinflate
+	rm -f TMP
+	echo "# This is a generated example; do not edit.  Rebuild with 'make docs'." >> TMP
+	echo " " >> TMP
+	/tmp/bin/kinflate init
+	cat $(config_file_name) >> TMP
+	mv TMP $(example_config)
+	rm $(config_file_name)
+
+/tmp/bin/kinflate:
+	go build -o /tmp/bin/kinflate kinflate.go

--- a/cmd/kinflate/docs/Kube-manifest.yaml
+++ b/cmd/kinflate/docs/Kube-manifest.yaml
@@ -1,0 +1,22 @@
+# This is a generated example; do not edit.  Rebuild with 'make docs'.
+ 
+apiVersion: manifest.k8s.io/v1alpha1
+kind: Manifest
+metadata:
+  name: helloworld
+description: helloworld does useful stuff.
+namePrefix: some-prefix
+# Labels to add to all objects and selectors.
+# These labels would also be used to form the selector for apply --prune
+# Named differently than “labels” to avoid confusion with metadata for this object
+objectLabels:
+  app: helloworld
+objectAnnotations:
+  note: This is an example annotation
+resources: []
+#- service.yaml
+#- ../some-dir/
+# There could also be configmaps in Base, which would make these overlays
+configMapGenerator: []
+# There could be secrets in Base, if just using a fork/rebase workflow
+secretGenerator: []

--- a/cmd/kinflate/docs/glossary.md
+++ b/cmd/kinflate/docs/glossary.md
@@ -139,6 +139,8 @@ kinflate is an implementation of [DAM].
 A _manifest_ is a file called `Kube-manifest.yaml` that
 describes a configuration consumable by [kinflate].
 
+Here's an [example](Kube-manifest.yaml).
+
 A manifest contains fields falling into these categories:
 
  * Immediate customization instructions -


### PR DESCRIPTION
We need some documentation for the manifest on the website.

Here's an initial structure, that uses the "kinflate init" command as a source of truth
to create an example that displays on the website.

To update the docs, create a branch, run "make docs", and merge the branch.

Down the road we could use the makefile to do more sophisticated inclusion of generated code with the website.

