### PR TITLE
kustomize: automate github release publishing

### DIFF
--- a/cmd/kustomize/build/.goreleaser.yml
+++ b/cmd/kustomize/build/.goreleaser.yml
@@ -1,0 +1,29 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: kustomize
+builds:
+- main: ./cmd/kustomize
+  binary: kustomize
+  ldflags: -s -X k8s.io/kubectl/cmd/kustomize/version.kustomizeVersion={{.Version}} -X k8s.io/kubectl/cmd/kustomize/version.gitCommit={{.Commit}} -X k8s.io/kubectl/cmd/kustomize/version.buildDate={{.Date}}
+  goos:
+  - darwin
+  - linux
+  - windows
+  env:
+  - CGO_ENABLED=0
+archive:
+  wrap_in_directory: true
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+release:
+  github:
+    owner: droot
+    name: kubectl

--- a/cmd/kustomize/build/cloudbuild.yaml
+++ b/cmd/kustomize/build/cloudbuild.yaml
@@ -16,15 +16,10 @@
 steps:
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output"]
-- name: "golang:1.10-stretch"
+- name: "gcr.io/kustomize-199618/golang_with_goreleaser:1.10-stretch"
   args: ["bash", "cmd/kustomize/build/build.sh"]
-  env:
-  - 'GOOS=${_GOOS}'
-  - 'GOARCH=${_GOARCH}'
-  - 'VERSION=${TAG_NAME}'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-h', 'Content-Type:application/gzip', 'cp', '-a', 'public-read', 'kustomize-${TAG_NAME}-${_GOOS}-${_GOARCH}.tar.gz', 'gs://kustomize-release/kustomize-${TAG_NAME}-${_GOOS}-${_GOARCH}.tar.gz']
-  env:
-  - 'GOOS=${_GOOS}'
-  - 'GOARCH=${_GOARCH}'
-  - 'VERSION=${TAG_NAME}'
+  secretEnv: ['GITHUB_TOKEN']
+secrets:
+- kmsKeyName: projects/kustomize-199618/locations/global/keyRings/github-tokens/cryptoKeys/gh-release-token
+  secretEnv:
+   GITHUB_TOKEN: CiQAyrREbPgXJOeT7M3t+WlxkhXwlMPudixBeiyWTjmLOMLqdK4SUQA0W+xUmDJKAhyfHCcwqSEzUn9OwKC7XAYcmwe0CCKTCbPbDgmioDK24q3LVapndXNvnnHvCjhOJNEr1o+P1DCF+LlzYV2YL8lP09rrKrslPg==

--- a/cmd/kustomize/build/cloudbuild_local.yaml
+++ b/cmd/kustomize/build/cloudbuild_local.yaml
@@ -23,9 +23,10 @@
 steps:
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output"]
-- name: "golang:1.10-stretch"
+- name: "gcr.io/kustomize-199618/golang_with_goreleaser:1.10-stretch"
   args: ["bash", "cmd/kustomize/build/build.sh"]
-  env:
-  - 'GOOS=${_GOOS}'
-  - 'GOARCH=${_GOARCH}'
-  - 'VERSION=${TAG_NAME}'
+  secretEnv: ['GITHUB_TOKEN']
+secrets:
+- kmsKeyName: projects/kustomize-199618/locations/global/keyRings/github-tokens/cryptoKeys/gh-release-token
+  secretEnv:
+   GITHUB_TOKEN: CiQAyrREbPgXJOeT7M3t+WlxkhXwlMPudixBeiyWTjmLOMLqdK4SUQA0W+xUmDJKAhyfHCcwqSEzUn9OwKC7XAYcmwe0CCKTCbPbDgmioDK24q3LVapndXNvnnHvCjhOJNEr1o+P1DCF+LlzYV2YL8lP09rrKrslPg==


### PR DESCRIPTION
An example release looks like:

https://github.com/droot/kubectl/releases/tag/v0.1.0