### PR TITLE
Add owners section for subproject owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,6 @@
+owners:
+  - pwittrock
+  - soltysh
 approvers:
   - pwittrock
   - soltysh


### PR DESCRIPTION
Add an 'owners' section of the OWNERS file. Members of this section are specifically enumerated as the Subproject Owner role for the 'kubeclt' subproject in the SIG CLI charter.