### PR TITLE
kubectl book: Fix exec examples caused by bad refactoring

### DIFF
--- a/docs/book/pages/app_composition_and_deployment/accessing_multiple_clusters.md
+++ b/docs/book/pages/app_composition_and_deployment/accessing_multiple_clusters.md
@@ -27,7 +27,7 @@ List the contexts in the kubeconfig file
 
 {% sample lang="yaml" %}
 ```sh
-deploykubectl config get-contexts
+$ kubectl config get-contexts
 ```
 
 ```sh
@@ -47,7 +47,7 @@ Print information about the current context
 
 {% sample lang="yaml" %}
 ```sh
-deploykubectl config --kubeconfig=config-demo view --minify
+$ kubectl config --kubeconfig=config-demo view --minify
 ```
 
 ```yaml
@@ -87,7 +87,7 @@ the name of the context.
 {% sample lang="yaml" %}
 
 ```sh
-deployexport CLUSTER=us-west2-c; kubectl apply -k ${CLUSTER} --context=${CLUSTER}
+$ export CLUSTER=us-west2-c; kubectl apply -k ${CLUSTER} --context=${CLUSTER}
 ```
 
 {% endmethod %}
@@ -105,9 +105,9 @@ the name of the context.
 
 ```sh
 # change the context to us-west2-c
-deploykubectl config use-context us-west2-c
+$ kubectl config use-context us-west2-c
 # deploy Resources from the ./us-west2-c/kustomization.yaml
-deploykubectl apply -k ./us-west2-c
+$ kubectl apply -k ./us-west2-c
 ```
 
 {% endmethod %}
@@ -125,7 +125,7 @@ the name of the directory containing the kubeconfig.
 {% sample lang="yaml" %}
 
 ```sh
-deploykubectl apply -k ./us-west2-c --kubeconfig /path/to/us-west2-c/config
+$ kubectl apply -k ./us-west2-c --kubeconfig /path/to/us-west2-c/config
 ```
 
 {% endmethod %}

--- a/docs/book/pages/app_composition_and_deployment/accessing_multiple_clusters.md
+++ b/docs/book/pages/app_composition_and_deployment/accessing_multiple_clusters.md
@@ -27,7 +27,7 @@ List the contexts in the kubeconfig file
 
 {% sample lang="yaml" %}
 ```sh
-$ kubectl config get-contexts
+kubectl config get-contexts
 ```
 
 ```sh
@@ -47,7 +47,7 @@ Print information about the current context
 
 {% sample lang="yaml" %}
 ```sh
-$ kubectl config --kubeconfig=config-demo view --minify
+kubectl config --kubeconfig=config-demo view --minify
 ```
 
 ```yaml
@@ -87,7 +87,7 @@ the name of the context.
 {% sample lang="yaml" %}
 
 ```sh
-$ export CLUSTER=us-west2-c; kubectl apply -k ${CLUSTER} --context=${CLUSTER}
+export CLUSTER=us-west2-c; kubectl apply -k ${CLUSTER} --context=${CLUSTER}
 ```
 
 {% endmethod %}
@@ -105,9 +105,9 @@ the name of the context.
 
 ```sh
 # change the context to us-west2-c
-$ kubectl config use-context us-west2-c
+kubectl config use-context us-west2-c
 # deploy Resources from the ./us-west2-c/kustomization.yaml
-$ kubectl apply -k ./us-west2-c
+kubectl apply -k ./us-west2-c
 ```
 
 {% endmethod %}
@@ -125,7 +125,7 @@ the name of the directory containing the kubeconfig.
 {% sample lang="yaml" %}
 
 ```sh
-$ kubectl apply -k ./us-west2-c --kubeconfig /path/to/us-west2-c/config
+kubectl apply -k ./us-west2-c --kubeconfig /path/to/us-west2-c/config
 ```
 
 {% endmethod %}

--- a/docs/book/pages/app_composition_and_deployment/diffing_local_and_remote_resources.md
+++ b/docs/book/pages/app_composition_and_deployment/diffing_local_and_remote_resources.md
@@ -17,7 +17,7 @@ made by Apply.
 {% sample lang="yaml" %}
 
 ```sh
-deploykubectl diff -k ./dir/
+$ kubectl diff -k ./dir/
 ```
 
 {% endmethod %}
@@ -33,7 +33,7 @@ By default, the "diff" command available in your path will be run with "-u" (uni
 {% sample lang="yaml" %}
 
 ```sh
-deployexport KUBECTL_EXTERNAL_DIFF=meld; kubectl diff -k ./dir/
+$ export KUBECTL_EXTERNAL_DIFF=meld; kubectl diff -k ./dir/
 ```
 
 {% endmethod %}

--- a/docs/book/pages/app_composition_and_deployment/diffing_local_and_remote_resources.md
+++ b/docs/book/pages/app_composition_and_deployment/diffing_local_and_remote_resources.md
@@ -17,7 +17,7 @@ made by Apply.
 {% sample lang="yaml" %}
 
 ```sh
-$ kubectl diff -k ./dir/
+kubectl diff -k ./dir/
 ```
 
 {% endmethod %}
@@ -33,7 +33,7 @@ By default, the "diff" command available in your path will be run with "-u" (uni
 {% sample lang="yaml" %}
 
 ```sh
-$ export KUBECTL_EXTERNAL_DIFF=meld; kubectl diff -k ./dir/
+export KUBECTL_EXTERNAL_DIFF=meld; kubectl diff -k ./dir/
 ```
 
 {% endmethod %}

--- a/docs/book/pages/app_composition_and_deployment/structure_branches.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_branches.md
@@ -83,7 +83,7 @@ Techniques:
 **Base Branch:**
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases
 │   ├── ...
@@ -113,7 +113,7 @@ deploytree
 **Deploy Branches:**
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -129,7 +129,7 @@ deploytree
 ```
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -141,7 +141,7 @@ deploytree
 ```
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -196,7 +196,7 @@ Techniques:
 **Base Branch:**
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases
 │   ├── ...
@@ -226,7 +226,7 @@ deploytree
 **Deploy Branches:**
 
 ```bash
-deploytree
+$ tree
 .
 └── deploy-prod
     ├── us-central
@@ -238,7 +238,7 @@ deploytree
 ```
 
 ```bash
-deploytree
+$ tree
 .
 └── deploy-staging
     └── us-west
@@ -246,7 +246,7 @@ deploytree
 ```
 
 ```bash
-deploytree
+$ tree
 .
 └── deploy-test
     └── us-west

--- a/docs/book/pages/app_composition_and_deployment/structure_branches.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_branches.md
@@ -83,7 +83,7 @@ Techniques:
 **Base Branch:**
 
 ```bash
-$ tree
+tree
 .
 ├── bases
 │   ├── ...
@@ -113,7 +113,7 @@ $ tree
 **Deploy Branches:**
 
 ```bash
-$ tree
+tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -129,7 +129,7 @@ $ tree
 ```
 
 ```bash
-$ tree
+tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -141,7 +141,7 @@ $ tree
 ```
 
 ```bash
-$ tree
+tree
 .
 ├── bases # From Base Branch
 │   ├── ...
@@ -196,7 +196,7 @@ Techniques:
 **Base Branch:**
 
 ```bash
-$ tree
+tree
 .
 ├── bases
 │   ├── ...
@@ -226,7 +226,7 @@ $ tree
 **Deploy Branches:**
 
 ```bash
-$ tree
+tree
 .
 └── deploy-prod
     ├── us-central
@@ -238,7 +238,7 @@ $ tree
 ```
 
 ```bash
-$ tree
+tree
 .
 └── deploy-staging
     └── us-west
@@ -246,7 +246,7 @@ $ tree
 ```
 
 ```bash
-$ tree
+tree
 .
 └── deploy-test
     └── us-west

--- a/docs/book/pages/app_composition_and_deployment/structure_directories.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_directories.md
@@ -72,7 +72,7 @@ Techniques:
 {% sample lang="yaml" %}
 
 ```bash
-$ tree
+tree
 .
 ├── bases # Used as a Base only
 │   ├── kustomization.yaml

--- a/docs/book/pages/app_composition_and_deployment/structure_directories.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_directories.md
@@ -72,7 +72,7 @@ Techniques:
 {% sample lang="yaml" %}
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases # Used as a Base only
 │   ├── kustomization.yaml

--- a/docs/book/pages/app_composition_and_deployment/structure_repositories.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_repositories.md
@@ -77,7 +77,7 @@ Techniques:
 **Base Repository:**
 
 ```bash
-deploytree
+$ tree
 .
 ├── bases # Used as a Base only
 │   ├── kustomization.yaml
@@ -124,7 +124,7 @@ deploytree
 
 ```bash
 # sre team
-deploytree
+$ tree
 .
 ├── prod
 │   ├── us-central
@@ -137,7 +137,7 @@ deploytree
 
 ```bash
 # qa team
-deploytree
+$ tree
 .
 ├── staging # Staging
 │   └── us-west 
@@ -146,7 +146,7 @@ deploytree
 
 ```bash
 # dev team
-deploytree
+$ tree
 .
 └── test # Test
     └── us-west 

--- a/docs/book/pages/app_composition_and_deployment/structure_repositories.md
+++ b/docs/book/pages/app_composition_and_deployment/structure_repositories.md
@@ -77,7 +77,7 @@ Techniques:
 **Base Repository:**
 
 ```bash
-$ tree
+tree
 .
 ├── bases # Used as a Base only
 │   ├── kustomization.yaml
@@ -124,7 +124,7 @@ $ tree
 
 ```bash
 # sre team
-$ tree
+tree
 .
 ├── prod
 │   ├── us-central
@@ -137,7 +137,7 @@ $ tree
 
 ```bash
 # qa team
-$ tree
+tree
 .
 ├── staging # Staging
 │   └── us-west 
@@ -146,7 +146,7 @@ $ tree
 
 ```bash
 # dev team
-$ tree
+tree
 .
 └── test # Test
     └── us-west 

--- a/docs/book/pages/app_management/apply.md
+++ b/docs/book/pages/app_management/apply.md
@@ -72,10 +72,10 @@ ResourceConfig files using `-f`.
 {% sample lang="yaml" %}
 ```bash
 # Apply the Resource Config
-$ kubectl apply -k .
+kubectl apply -k .
 
 # View the Resources
-$ kubectl get -k .
+kubectl get -k .
 ```
 {% endmethod %}
 

--- a/docs/book/pages/app_management/apply.md
+++ b/docs/book/pages/app_management/apply.md
@@ -72,10 +72,10 @@ ResourceConfig files using `-f`.
 {% sample lang="yaml" %}
 ```bash
 # Apply the Resource Config
-deploykubectl apply -k .
+$ kubectl apply -k .
 
 # View the Resources
-deploykubectl get -k .
+$ kubectl get -k .
 ```
 {% endmethod %}
 

--- a/docs/book/pages/app_management/container_images.md
+++ b/docs/book/pages/app_management/container_images.md
@@ -165,8 +165,8 @@ download the [kustomize standalone](https://github.com/kubernetes-sigs/kustomize
 
 {% sample lang="yaml" %}
 ```bash
-$ kustomize edit set imagetag foo:$(git log -n 1 --pretty=format:"%H")
-$ kubectl apply -f .
+kustomize edit set imagetag foo:$(git log -n 1 --pretty=format:"%H")
+kubectl apply -f .
 ```
 {% endmethod %}
 
@@ -179,8 +179,8 @@ It is also possible to set a Tag from an environment variable using the same tec
 
 {% sample lang="yaml" %}
 ```bash
-$ kustomize edit set image foo:$FOO_IMAGE_TAG
-$ kubectl apply -f .
+kustomize edit set image foo:$FOO_IMAGE_TAG
+kubectl apply -f .
 ```
 {% endmethod %}
 

--- a/docs/book/pages/app_management/container_images.md
+++ b/docs/book/pages/app_management/container_images.md
@@ -165,8 +165,8 @@ download the [kustomize standalone](https://github.com/kubernetes-sigs/kustomize
 
 {% sample lang="yaml" %}
 ```bash
-deploykustomize edit set imagetag foo:$(git log -n 1 --pretty=format:"%H")
-deploykubectl apply -f .
+$ kustomize edit set imagetag foo:$(git log -n 1 --pretty=format:"%H")
+$ kubectl apply -f .
 ```
 {% endmethod %}
 
@@ -179,8 +179,8 @@ It is also possible to set a Tag from an environment variable using the same tec
 
 {% sample lang="yaml" %}
 ```bash
-deploykustomize edit set image foo:$FOO_IMAGE_TAG
-deploykubectl apply -f .
+$ kustomize edit set image foo:$FOO_IMAGE_TAG
+$ kubectl apply -f .
 ```
 {% endmethod %}
 

--- a/docs/book/pages/container_debugging/container_logs.md
+++ b/docs/book/pages/container_debugging/container_logs.md
@@ -15,7 +15,7 @@ Print the logs for a Pod running a single Container
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl logs echo-c6bc8ccff-nnj52
+$ kubectl logs echo-c6bc8ccff-nnj52
 ```
 
 ```bash
@@ -42,7 +42,7 @@ Print the logs for all Pods for a Workload
 
 ```bash
 # Print logs from all containers matching label
-deploykubectl logs -l app=nginx
+$ kubectl logs -l app=nginx
 ```
 
 {% endmethod %}
@@ -65,7 +65,7 @@ Stream logs from a container.
 
 ```bash
 # Follow logs from container
-deploykubectl logs nginx-78f5d695bd-czm8z -f
+$ kubectl logs nginx-78f5d695bd-czm8z -f
 ```
 
 {% endmethod %}
@@ -81,7 +81,7 @@ crashed or are crash looping.
 
 ```bash
 # Print logs from exited container
-deploykubectl logs nginx-78f5d695bd-czm8z -p
+$ kubectl logs nginx-78f5d695bd-czm8z -p
 ```
 
 {% endmethod %}
@@ -97,7 +97,7 @@ containers.
 
 ```bash
 # Print logs from the nginx container in the nginx-78f5d695bd-czm8z Pod
-deploykubectl logs nginx-78f5d695bd-czm8z -c nginx
+$ kubectl logs nginx-78f5d695bd-czm8z -c nginx
 ```
 
 {% endmethod %}
@@ -112,7 +112,7 @@ Print the logs that occurred after an absolute time.
 
 ```bash
 # Print logs since a date
-deploykubectl logs nginx-78f5d695bd-czm8z --since-time=2018-11-01T15:00:00Z
+$ kubectl logs nginx-78f5d695bd-czm8z --since-time=2018-11-01T15:00:00Z
 ```
 
 {% endmethod %}
@@ -134,7 +134,7 @@ Examples:
 
 ```bash
 # Print logs for the past hour
-deploykubectl logs nginx-78f5d695bd-czm8z --since=1h
+$ kubectl logs nginx-78f5d695bd-czm8z --since=1h
 ```
 
 {% endmethod %}
@@ -150,7 +150,7 @@ Include timestamps in the log lines
 
 ```bash
 # Print logs with timestamps
-deploykubectl logs -l app=echo --timestamps
+$ kubectl logs -l app=echo --timestamps
 ```
 
 ```bash

--- a/docs/book/pages/container_debugging/container_logs.md
+++ b/docs/book/pages/container_debugging/container_logs.md
@@ -15,7 +15,7 @@ Print the logs for a Pod running a single Container
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl logs echo-c6bc8ccff-nnj52
+kubectl logs echo-c6bc8ccff-nnj52
 ```
 
 ```bash
@@ -42,7 +42,7 @@ Print the logs for all Pods for a Workload
 
 ```bash
 # Print logs from all containers matching label
-$ kubectl logs -l app=nginx
+kubectl logs -l app=nginx
 ```
 
 {% endmethod %}
@@ -65,7 +65,7 @@ Stream logs from a container.
 
 ```bash
 # Follow logs from container
-$ kubectl logs nginx-78f5d695bd-czm8z -f
+kubectl logs nginx-78f5d695bd-czm8z -f
 ```
 
 {% endmethod %}
@@ -81,7 +81,7 @@ crashed or are crash looping.
 
 ```bash
 # Print logs from exited container
-$ kubectl logs nginx-78f5d695bd-czm8z -p
+kubectl logs nginx-78f5d695bd-czm8z -p
 ```
 
 {% endmethod %}
@@ -97,7 +97,7 @@ containers.
 
 ```bash
 # Print logs from the nginx container in the nginx-78f5d695bd-czm8z Pod
-$ kubectl logs nginx-78f5d695bd-czm8z -c nginx
+kubectl logs nginx-78f5d695bd-czm8z -c nginx
 ```
 
 {% endmethod %}
@@ -112,7 +112,7 @@ Print the logs that occurred after an absolute time.
 
 ```bash
 # Print logs since a date
-$ kubectl logs nginx-78f5d695bd-czm8z --since-time=2018-11-01T15:00:00Z
+kubectl logs nginx-78f5d695bd-czm8z --since-time=2018-11-01T15:00:00Z
 ```
 
 {% endmethod %}
@@ -134,7 +134,7 @@ Examples:
 
 ```bash
 # Print logs for the past hour
-$ kubectl logs nginx-78f5d695bd-czm8z --since=1h
+kubectl logs nginx-78f5d695bd-czm8z --since=1h
 ```
 
 {% endmethod %}
@@ -150,7 +150,7 @@ Include timestamps in the log lines
 
 ```bash
 # Print logs with timestamps
-$ kubectl logs -l app=echo --timestamps
+kubectl logs -l app=echo --timestamps
 ```
 
 ```bash

--- a/docs/book/pages/container_debugging/copying_container_files.md
+++ b/docs/book/pages/container_debugging/copying_container_files.md
@@ -24,7 +24,7 @@ Copy a local file to a remote Pod in a cluster.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
+$ kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
 ```
 
 {% endmethod %}
@@ -40,7 +40,7 @@ Copy a remote file from a Pod to a local file.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo <some-pod>:/tmp/bar
+$ kubectl cp /tmp/foo <some-pod>:/tmp/bar
 ```
 
 {% endmethod %}
@@ -55,7 +55,7 @@ Specify the Container within a Pod running multiple containers.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+$ kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
 ```
 
 {% endmethod %}
@@ -70,7 +70,7 @@ Set the Pod namespace by prefixing the Pod name with `<namespace>/` .
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+$ kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 ```
 
 {% endmethod %}

--- a/docs/book/pages/container_debugging/copying_container_files.md
+++ b/docs/book/pages/container_debugging/copying_container_files.md
@@ -24,7 +24,7 @@ Copy a local file to a remote Pod in a cluster.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
+kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
 ```
 
 {% endmethod %}
@@ -40,7 +40,7 @@ Copy a remote file from a Pod to a local file.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo <some-pod>:/tmp/bar
+kubectl cp /tmp/foo <some-pod>:/tmp/bar
 ```
 
 {% endmethod %}
@@ -55,7 +55,7 @@ Specify the Container within a Pod running multiple containers.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
 ```
 
 {% endmethod %}
@@ -70,7 +70,7 @@ Set the Pod namespace by prefixing the Pod name with `<namespace>/` .
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 ```
 
 {% endmethod %}

--- a/docs/book/pages/container_debugging/executing_a_command_in_a_container.md
+++ b/docs/book/pages/container_debugging/executing_a_command_in_a_container.md
@@ -35,7 +35,7 @@ To get a Shell in a Container, use the `-t -i` options to get a tty and attach S
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl exec -t -i nginx-78f5d695bd-czm8z bash
+$ kubectl exec -t -i nginx-78f5d695bd-czm8z bash
 ```
 
 ```bash

--- a/docs/book/pages/container_debugging/executing_a_command_in_a_container.md
+++ b/docs/book/pages/container_debugging/executing_a_command_in_a_container.md
@@ -35,7 +35,7 @@ To get a Shell in a Container, use the `-t -i` options to get a tty and attach S
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl exec -t -i nginx-78f5d695bd-czm8z bash
+kubectl exec -t -i nginx-78f5d695bd-czm8z bash
 ```
 
 ```bash

--- a/docs/book/pages/container_debugging/port_forward_to_pods.md
+++ b/docs/book/pages/container_debugging/port_forward_to_pods.md
@@ -15,7 +15,7 @@ Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 60
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl port-forward pod/mypod 5000 6000
+$ kubectl port-forward pod/mypod 5000 6000
 ```
 
 {% endmethod %}
@@ -30,7 +30,7 @@ deployment
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl port-forward deployment/mydeployment 5000 6000
+$ kubectl port-forward deployment/mydeployment 5000 6000
 ```
 
 {% endmethod %}
@@ -44,7 +44,7 @@ Listen on port 8888 locally, forwarding to 5000 in the pod
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl port-forward pod/mypod 8888:5000
+$ kubectl port-forward pod/mypod 8888:5000
 ```
 
 {% endmethod %}
@@ -58,7 +58,7 @@ Listen on a random port locally, forwarding to 5000 in the pod
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl port-forward pod/mypod :5000
+$ kubectl port-forward pod/mypod :5000
 ```
 
 {% endmethod %}
@@ -74,7 +74,7 @@ Specify the Container within a Pod running multiple containers.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+$ kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
 ```
 
 {% endmethod %}
@@ -90,7 +90,7 @@ Set the Pod namespace by prefixing the Pod name with `<namespace>/` .
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+$ kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 ```
 
 {% endmethod %}

--- a/docs/book/pages/container_debugging/port_forward_to_pods.md
+++ b/docs/book/pages/container_debugging/port_forward_to_pods.md
@@ -15,7 +15,7 @@ Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 60
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl port-forward pod/mypod 5000 6000
+kubectl port-forward pod/mypod 5000 6000
 ```
 
 {% endmethod %}
@@ -30,7 +30,7 @@ deployment
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl port-forward deployment/mydeployment 5000 6000
+kubectl port-forward deployment/mydeployment 5000 6000
 ```
 
 {% endmethod %}
@@ -44,7 +44,7 @@ Listen on port 8888 locally, forwarding to 5000 in the pod
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl port-forward pod/mypod 8888:5000
+kubectl port-forward pod/mypod 8888:5000
 ```
 
 {% endmethod %}
@@ -58,7 +58,7 @@ Listen on a random port locally, forwarding to 5000 in the pod
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl port-forward pod/mypod :5000
+kubectl port-forward pod/mypod :5000
 ```
 
 {% endmethod %}
@@ -74,7 +74,7 @@ Specify the Container within a Pod running multiple containers.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
 ```
 
 {% endmethod %}
@@ -90,7 +90,7 @@ Set the Pod namespace by prefixing the Pod name with `<namespace>/` .
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 ```
 
 {% endmethod %}

--- a/docs/book/pages/container_debugging/proxying_traffic_to_services.md
+++ b/docs/book/pages/container_debugging/proxying_traffic_to_services.md
@@ -28,13 +28,13 @@ To visit the nginx service go to the Proxy URL at
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl proxy
+$ kubectl proxy
 
 Starting to serve on 127.0.0.1:8001
 ```
 
 ```bash
-deploycurl http://127.0.0.1:8001/api/v1/namespaces/default/services/nginx/proxy/
+$ curl http://127.0.0.1:8001/api/v1/namespaces/default/services/nginx/proxy/
 ```
 
 {% endmethod %}
@@ -56,7 +56,7 @@ A common usecase is to connect to Services running as part of the cluster itself
 Services and their Proxy Urls with `kubectl cluster-info`.
 
 ```bash
-deploykubectl cluster-info
+$ kubectl cluster-info
 
 Kubernetes master is running at https://104.197.5.247
 GLBCDefaultBackend is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/default-http-backend:http/proxy

--- a/docs/book/pages/container_debugging/proxying_traffic_to_services.md
+++ b/docs/book/pages/container_debugging/proxying_traffic_to_services.md
@@ -28,13 +28,13 @@ To visit the nginx service go to the Proxy URL at
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl proxy
+kubectl proxy
 
 Starting to serve on 127.0.0.1:8001
 ```
 
 ```bash
-$ curl http://127.0.0.1:8001/api/v1/namespaces/default/services/nginx/proxy/
+curl http://127.0.0.1:8001/api/v1/namespaces/default/services/nginx/proxy/
 ```
 
 {% endmethod %}
@@ -56,7 +56,7 @@ A common usecase is to connect to Services running as part of the cluster itself
 Services and their Proxy Urls with `kubectl cluster-info`.
 
 ```bash
-$ kubectl cluster-info
+kubectl cluster-info
 
 Kubernetes master is running at https://104.197.5.247
 GLBCDefaultBackend is running at https://104.197.5.247/api/v1/namespaces/kube-system/services/default-http-backend:http/proxy

--- a/docs/book/pages/resource_printing/cluster_information.md
+++ b/docs/book/pages/resource_printing/cluster_information.md
@@ -24,7 +24,7 @@ source.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl version
+kubectl version
 ```
 
 ```bash
@@ -49,7 +49,7 @@ add-ons.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl cluster-info
+kubectl cluster-info
 ```
 
 ```bash
@@ -78,7 +78,7 @@ top nodes and pods.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl top node
+kubectl top node
 ```
 
 ```bash
@@ -104,7 +104,7 @@ Print the Resource Types available in the cluster.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl api-resources
+kubectl api-resources
 ```
 
 ```bash
@@ -127,7 +127,7 @@ Print the API versions available in the cluster.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl api-versions
+kubectl api-versions
 ```
 
 ```bash
@@ -159,7 +159,7 @@ Resource types.  This is useful for learning about the type.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl explain deployment --api-version apps/v1
+kubectl explain deployment --api-version apps/v1
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/cluster_information.md
+++ b/docs/book/pages/resource_printing/cluster_information.md
@@ -24,7 +24,7 @@ source.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl version
+$ kubectl version
 ```
 
 ```bash
@@ -49,7 +49,7 @@ add-ons.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl cluster-info
+$ kubectl cluster-info
 ```
 
 ```bash
@@ -78,7 +78,7 @@ top nodes and pods.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl top node
+$ kubectl top node
 ```
 
 ```bash
@@ -104,7 +104,7 @@ Print the Resource Types available in the cluster.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl api-resources
+$ kubectl api-resources
 ```
 
 ```bash
@@ -127,7 +127,7 @@ Print the API versions available in the cluster.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl api-versions
+$ kubectl api-versions
 ```
 
 ```bash
@@ -159,7 +159,7 @@ Resource types.  This is useful for learning about the type.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl explain deployment --api-version apps/v1
+$ kubectl explain deployment --api-version apps/v1
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/describe.md
+++ b/docs/book/pages/resource_printing/describe.md
@@ -19,7 +19,7 @@ Resources, and formats and prints this information on multiple lines.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl describe deployments
+$ kubectl describe deployments
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/describe.md
+++ b/docs/book/pages/resource_printing/describe.md
@@ -19,7 +19,7 @@ Resources, and formats and prints this information on multiple lines.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl describe deployments
+kubectl describe deployments
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/fields.md
+++ b/docs/book/pages/resource_printing/fields.md
@@ -68,7 +68,7 @@ Print the JSON representation of the first Deployment in the list on a single li
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{.items[0]}{"\n"}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{.items[0]}{"\n"}'
 
 ```
 
@@ -86,7 +86,7 @@ Print the `metadata.name` field for the first Deployment in the list.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{.items[0].metadata.name}{"\n"}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{.items[0].metadata.name}{"\n"}'
 ```
 
 ```bash
@@ -104,7 +104,7 @@ For each Deployment, print its `metadata.name` field and a newline afterward.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
 ```
 
 ```bash
@@ -123,7 +123,7 @@ For each Deployment, print its `metadata.name` and `.status.availableReplicas`.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.availableReplicas}{"\n"}{end}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.availableReplicas}{"\n"}{end}'
 ```
 ```bash
 nginx	1
@@ -141,7 +141,7 @@ Print the list of Deployments as single line.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{@}{"\n"}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{@}{"\n"}'
 ```
 
 ```bash
@@ -159,7 +159,7 @@ Print each Deployment on a new line.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{@}{"\n"}{end}'
+$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{@}{"\n"}{end}'
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/fields.md
+++ b/docs/book/pages/resource_printing/fields.md
@@ -68,7 +68,7 @@ Print the JSON representation of the first Deployment in the list on a single li
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{.items[0]}{"\n"}'
+kubectl get deployment.v1.apps -o=jsonpath='{.items[0]}{"\n"}'
 
 ```
 
@@ -86,7 +86,7 @@ Print the `metadata.name` field for the first Deployment in the list.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{.items[0].metadata.name}{"\n"}'
+kubectl get deployment.v1.apps -o=jsonpath='{.items[0].metadata.name}{"\n"}'
 ```
 
 ```bash
@@ -104,7 +104,7 @@ For each Deployment, print its `metadata.name` field and a newline afterward.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
 ```
 
 ```bash
@@ -123,7 +123,7 @@ For each Deployment, print its `metadata.name` and `.status.availableReplicas`.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.availableReplicas}{"\n"}{end}'
+kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.availableReplicas}{"\n"}{end}'
 ```
 ```bash
 nginx	1
@@ -141,7 +141,7 @@ Print the list of Deployments as single line.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{@}{"\n"}'
+kubectl get deployment.v1.apps -o=jsonpath='{@}{"\n"}'
 ```
 
 ```bash
@@ -159,7 +159,7 @@ Print each Deployment on a new line.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{@}{"\n"}{end}'
+kubectl get deployment.v1.apps -o=jsonpath='{range .items[*]}{@}{"\n"}{end}'
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/queries_and_options.md
+++ b/docs/book/pages/resource_printing/queries_and_options.md
@@ -15,7 +15,7 @@ Get all Resources provided by the `kustomization.yaml` in project/.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get -k project/
+kubectl get -k project/
 ```
 
 {% endmethod %}
@@ -27,7 +27,7 @@ Get all Resources present in the Resource Config for a directory.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get -f configs/
+kubectl get -f configs/
 ```
 
 {% endmethod %}
@@ -44,17 +44,17 @@ The Singular, Plural, Short Name also apply to *Types with Name* and *Types with
 
 ```bash
 # Plural
-$ kubectl get deployments
+kubectl get deployments
 ```
 
 ```bash
 # Singular
-$ kubectl get deployment
+kubectl get deployment
 ```
 
 ```bash
 # Short name
-$ kubectl get deploy
+kubectl get deploy
 ```
 
 {% endmethod %}
@@ -69,11 +69,11 @@ The Group and Version for the Resource are explicit.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments.apps
+kubectl get deployments.apps
 ```
 
 ```bash
-$ kubectl get deployments.v1.apps
+kubectl get deployments.v1.apps
 ```
 
 {% endmethod %}
@@ -86,7 +86,7 @@ Get named Resources in a namespace for a given type.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment nginx
+kubectl get deployment nginx
 ```
 
 {% endmethod %}
@@ -98,7 +98,7 @@ Get **all** Resources in a namespace **matching a label select** for a given typ
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments -l app=nginx
+kubectl get deployments -l app=nginx
 ```
 
 {% endmethod %}
@@ -114,7 +114,7 @@ The `---all-namespaces` flag will **fetch Resources from all namespaces**.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments --all-namespaces
+kubectl get deployments --all-namespaces
 ```
 
 {% endmethod %}
@@ -128,7 +128,7 @@ Get and Describe can accept **multiple Resource types**, and it will print them 
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments,services
+kubectl get deployments,services
 ```
 
 {% endmethod %}
@@ -142,7 +142,7 @@ Get and Describe can accept **multiple Resource types and names**.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get kubectl get rc/web service/frontend pods/web-pod-13je7
+kubectl get kubectl get rc/web service/frontend pods/web-pod-13je7
 ```
 
 {% endmethod %}
@@ -156,7 +156,7 @@ These Resources can be view with the `--include-uninitialized` flag.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments --include-uninitialized
+kubectl get deployments --include-uninitialized
 ```
 
 {% endmethod %}
@@ -170,7 +170,7 @@ The `--ignore-not-found` flag will cause kubectl to exit 0 if the Resource is no
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment nginx --ignore-not-found
+kubectl get deployment nginx --ignore-not-found
 ```
 
 {% endmethod %}

--- a/docs/book/pages/resource_printing/queries_and_options.md
+++ b/docs/book/pages/resource_printing/queries_and_options.md
@@ -15,7 +15,7 @@ Get all Resources provided by the `kustomization.yaml` in project/.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get -k project/
+$ kubectl get -k project/
 ```
 
 {% endmethod %}
@@ -27,7 +27,7 @@ Get all Resources present in the Resource Config for a directory.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get -f configs/
+$ kubectl get -f configs/
 ```
 
 {% endmethod %}
@@ -44,17 +44,17 @@ The Singular, Plural, Short Name also apply to *Types with Name* and *Types with
 
 ```bash
 # Plural
-deploykubectl get deployments
+$ kubectl get deployments
 ```
 
 ```bash
 # Singular
-deploykubectl get deployment
+$ kubectl get deployment
 ```
 
 ```bash
 # Short name
-deploykubectl get deploy
+$ kubectl get deploy
 ```
 
 {% endmethod %}
@@ -69,11 +69,11 @@ The Group and Version for the Resource are explicit.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments.apps
+$ kubectl get deployments.apps
 ```
 
 ```bash
-deploykubectl get deployments.v1.apps
+$ kubectl get deployments.v1.apps
 ```
 
 {% endmethod %}
@@ -86,7 +86,7 @@ Get named Resources in a namespace for a given type.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment nginx
+$ kubectl get deployment nginx
 ```
 
 {% endmethod %}
@@ -98,7 +98,7 @@ Get **all** Resources in a namespace **matching a label select** for a given typ
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments -l app=nginx
+$ kubectl get deployments -l app=nginx
 ```
 
 {% endmethod %}
@@ -114,7 +114,7 @@ The `---all-namespaces` flag will **fetch Resources from all namespaces**.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments --all-namespaces
+$ kubectl get deployments --all-namespaces
 ```
 
 {% endmethod %}
@@ -128,7 +128,7 @@ Get and Describe can accept **multiple Resource types**, and it will print them 
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments,services
+$ kubectl get deployments,services
 ```
 
 {% endmethod %}
@@ -142,7 +142,7 @@ Get and Describe can accept **multiple Resource types and names**.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get kubectl get rc/web service/frontend pods/web-pod-13je7
+$ kubectl get kubectl get rc/web service/frontend pods/web-pod-13je7
 ```
 
 {% endmethod %}
@@ -156,7 +156,7 @@ These Resources can be view with the `--include-uninitialized` flag.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments --include-uninitialized
+$ kubectl get deployments --include-uninitialized
 ```
 
 {% endmethod %}
@@ -170,7 +170,7 @@ The `--ignore-not-found` flag will cause kubectl to exit 0 if the Resource is no
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment nginx --ignore-not-found
+$ kubectl get deployment nginx --ignore-not-found
 ```
 
 {% endmethod %}

--- a/docs/book/pages/resource_printing/raw.md
+++ b/docs/book/pages/resource_printing/raw.md
@@ -32,7 +32,7 @@ Print the Raw Resource formatting it as YAML.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments -o yaml
+$ kubectl get deployments -o yaml
 ```
 
 ```yaml
@@ -120,7 +120,7 @@ Print the Raw Resource formatting it as JSON.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments -o json
+$ kubectl get deployments -o json
 ```
 
 ```json

--- a/docs/book/pages/resource_printing/raw.md
+++ b/docs/book/pages/resource_printing/raw.md
@@ -32,7 +32,7 @@ Print the Raw Resource formatting it as YAML.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments -o yaml
+kubectl get deployments -o yaml
 ```
 
 ```yaml
@@ -120,7 +120,7 @@ Print the Raw Resource formatting it as JSON.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments -o json
+kubectl get deployments -o json
 ```
 
 ```json

--- a/docs/book/pages/resource_printing/summaries.md
+++ b/docs/book/pages/resource_printing/summaries.md
@@ -29,7 +29,7 @@ be a summary of fields.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments nginx
+$ kubectl get deployments nginx
 ```
 
 ```bash
@@ -52,7 +52,7 @@ be a summary of fields.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get -o=wide deployments nginx
+$ kubectl get -o=wide deployments nginx
 ```
 
 ```bash
@@ -74,7 +74,7 @@ Print out specific fields as Columns.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments -o custom-columns="Name:metadata.name,Replicas:spec.replicas,Strategy:spec.strategy.type"
+$ kubectl get deployments -o custom-columns="Name:metadata.name,Replicas:spec.replicas,Strategy:spec.strategy.type"
 ```
 
 ```bash
@@ -112,7 +112,7 @@ Print out all labels on each Resource in a single column (last).
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployment --show-labels
+$ kubectl get deployment --show-labels
 ```
 
 ```bash
@@ -135,7 +135,7 @@ they want to know which API is being used.
 {% sample lang="yaml" %}
 
 ```bash
-deploykubectl get deployments --show-kind
+$ kubectl get deployments --show-kind
 ```
 
 ```bash

--- a/docs/book/pages/resource_printing/summaries.md
+++ b/docs/book/pages/resource_printing/summaries.md
@@ -29,7 +29,7 @@ be a summary of fields.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments nginx
+kubectl get deployments nginx
 ```
 
 ```bash
@@ -52,7 +52,7 @@ be a summary of fields.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get -o=wide deployments nginx
+kubectl get -o=wide deployments nginx
 ```
 
 ```bash
@@ -74,7 +74,7 @@ Print out specific fields as Columns.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments -o custom-columns="Name:metadata.name,Replicas:spec.replicas,Strategy:spec.strategy.type"
+kubectl get deployments -o custom-columns="Name:metadata.name,Replicas:spec.replicas,Strategy:spec.strategy.type"
 ```
 
 ```bash
@@ -112,7 +112,7 @@ Print out all labels on each Resource in a single column (last).
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployment --show-labels
+kubectl get deployment --show-labels
 ```
 
 ```bash
@@ -135,7 +135,7 @@ they want to know which API is being used.
 {% sample lang="yaml" %}
 
 ```bash
-$ kubectl get deployments --show-kind
+kubectl get deployments --show-kind
 ```
 
 ```bash


### PR DESCRIPTION
- refactoring replaced '$ ' with 'deploy'
- should have replaced '$ ' with ''