### PR TITLE
Remove cp examples from the port-forward page

### DIFF
--- a/docs/book/pages/container_debugging/port_forward_to_pods.md
+++ b/docs/book/pages/container_debugging/port_forward_to_pods.md
@@ -62,35 +62,3 @@ kubectl port-forward pod/mypod :5000
 ```
 
 {% endmethod %}
-
----
-
-{% method %}
-## Specify the Container
-
-Specify the Container within a Pod running multiple containers.
-
-- `-c <container-name>`
-{% sample lang="yaml" %}
-
-```bash
-kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
-```
-
-{% endmethod %}
-  
----
-
-{% method %}
-## Namespaces
-
-Set the Pod namespace by prefixing the Pod name with `<namespace>/` .
-
-- `<pod-namespace>/<pod-name>:<path>`
-{% sample lang="yaml" %}
-
-```bash
-kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
-```
-
-{% endmethod %}


### PR DESCRIPTION
The examples at the end of the port_forward_to_pods page are derived
from the copying_container_files page when it was created.