### PR TITLE
feat(docs): add section on environment style configmap/secret generation

### DIFF
--- a/docs/book/pages/app_management/secrets_and_configmaps.md
+++ b/docs/book/pages/app_management/secrets_and_configmaps.md
@@ -112,6 +112,56 @@ data:
 ```
 {% endmethod %}
 
+### ConfigMaps From Environment Files
+
+ConfigMap Resources may be generated from key-value pairs much the same as using the literals option
+but taking the key-value pairs from an environment file. These generally end in `.env`.
+To generate a ConfigMap Resource from an environment file, add an entry to `configMapGenerator` with a
+single `env` entry, e.g. `env: config.env`.
+
+{% panel style="info", title="Environment File Syntax" %}
+- The key/value pairs inside of the environment file are separated by a `=` sign (left side is the key)
+- The value of each line will appear as a data item in the ConfigMap keyed by its key.
+{% endpanel %}
+
+{% method %}
+**Example:** Create a ConfigMap with 3 data items generated from an environment file.
+
+{% sample lang="yaml" %}
+**Input:** The kustomization.yaml file
+
+```yaml
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: tracing-options
+  env: tracing.env
+```
+
+```bash
+# tracing.env
+ENABLE_TRACING=true
+SAMPLER_TYPE=probabilistic
+SAMPLER_PARAMETERS=0.1
+```
+
+**Applied:** The Resource that is Applied to the cluster
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # The name has had a suffix applied
+  name: tracing-options-6bh8gkdf7k
+# The data has been populated from each literal pair
+data:
+  ENABLE_TRACING: "true"
+  SAMPLER_TYPE: "probabilistic"
+  SAMPLER_PARAMETERS: "0.1"
+```
+{% endmethod %}
+
 {% panel style="success", title="Overriding Base ConfigMap Values" %}
 ConfigMaps Values from Bases may be overridden by adding another generator for the ConfigMap
 in the Variant and specifying the `behavior` field.  `behavior` may be
@@ -122,7 +172,8 @@ for more on using Bases.  e.g. `behavior: "merge"`
 
 ### Secrets from Files
 
-Secret Resources may be generated from files much like ConfigMaps can.
+Secret Resources may be generated much like ConfigMaps can. This includes generating them
+from literals, files or environment files.
 
 {% panel style="info", title="Secret Syntax" %}
 Secret type is set using the `type` field.


### PR DESCRIPTION
This adds an example of generating configmaps/secrets using the `env` option.
It also adds a bit of clarification that the same `literals`, `files` and `env` options can be used for secrets.

closes #632 