### PR TITLE
diff.go: add the missing '.' in 'kubectl diff -h' output.

### DIFF
--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -148,7 +148,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
-	usage := "contains the configuration to diff"
+	usage := "contains the configuration to diff."
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmdutil.AddServerSideApplyFlags(cmd)


### PR DESCRIPTION
diff.go: add the missing '.' in 'kubectl diff -h' output.

Signed-off-by: ZhenLiu94 <zhenliu94@163.com>

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
