### PR TITLE
Allow to annotate LDAP objects

### DIFF
--- a/pkg/cmd/util/helpers.go
+++ b/pkg/cmd/util/helpers.go
@@ -605,6 +605,13 @@ func GetResourcesAndPairs(args []string, pairType string) (resources []string, p
 			return
 		}
 	}
+	// In case of annotation of LDAP object, the resource itself may contain '='
+	// For example: CN=Group1,OU=Groups,OU=People,DC=example,DC=local
+	// in such cases the first item in pairArgs will be considered as a resource
+	if len(resources) == 0 {
+		resources = append(resources, pairArgs[0])
+		pairArgs  = append(pairArgs[:0], pairArgs[0+1:]...)
+	}
 	return
 }
 


### PR DESCRIPTION
`$ kubectl annotate CN=Group1,OU=Groups,OU=People,DC=example,DC=local foo=bar`

This is tricky, because both arguments contains `=` they are considered to be annotations pairs:

```
CN=Group1,OU=Groups,OU=People,DC=example,DC=local
foo=bar
```

And the resource we want to annotate is missing.

Hence the error message:
`one or more resources must be specified as <resource> <name> or <resource>/<name>`

At the moment, same functions parsing the resource and pairs,
just by the logic whether the string contains `=`.

We could add a check if no resource has been found at the end,
for example in case of LDAP, then we could use the first found "pair" as a resource?

It wouldn't cause problem with the positions since resource are positional:
https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/util/helpers.go#L603-L606

So even if the annotations and resource is misplaced, the added check
for empty resources wouldn't even trigger and client would fail with the
error of misplacement.

This changes would allow to have something like like `kubectl annotate CN=Group1,OU=Groups,OU=People,DC=example,DC=local foo=bar`

It would iterate over all arguments and it would fail to find the resource,
but since we know there is no resource, we could try to take the first one from the pairs.

Even with  single argument, it would still not proceed. Which looks promising.
```
error: at least one annotation update is required
```

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
