### PR TITLE
Improve conditionFuncFor expression parsing for wait --for jsonpath

### DIFF
--- a/pkg/cmd/wait/wait.go
+++ b/pkg/cmd/wait/wait.go
@@ -207,10 +207,12 @@ func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error)
 	}
 	if strings.HasPrefix(condition, "jsonpath=") {
 		splitStr := strings.Split(condition, "=")
-		if len(splitStr) != 3 {
+		if len(splitStr) < 3 {
 			return nil, fmt.Errorf("jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3")
 		}
-		jsonPathExp, jsonPathCond, err := processJSONPathInput(splitStr[1], splitStr[2])
+		jsonPathExp, jsonPathCond, err := processJSONPathInput(
+			strings.Join(splitStr[1:len(splitStr)-1], "="),
+			splitStr[len(splitStr)-1])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Make it possible to parse jsonpath filter expressions: After splitting the condition for jsonpath, drop the first element containing the prefix, use the last element as the condition and join all middle elements as the expression.

Reported-at: https://github.com/kubernetes/kubectl/issues/1224

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
