### PR TITLE
migrate broken link from k8s-testgrid.appspot.com to testgrid.k8s.io …

### DIFF
--- a/docs/maintainers/MAINTAINERS.md
+++ b/docs/maintainers/MAINTAINERS.md
@@ -37,7 +37,7 @@ Look for:
 
 ### Test triage
 
-Monitor [test grid](https://k8s-testgrid.appspot.com/sig-cli-master)
+Monitor [test grid](https://testgrid.k8s.io/sig-cli-master)
 and make sure the tests are passing.
 
 If any tests are failing, debug them and send a fix.  Ask for help if you get stuck.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Fixes a broken link to testgrid dashboard in docs/maintainers/MAINTAINERS.md

**Which issue(s) this PR fixes:**
This is related to an umbrella issue and fixes a task of the same:
https://github.com/kubernetes/test-infra/issues/30370