### PR TITLE
fix: create secret tls certificate name extension

### DIFF
--- a/pkg/cmd/create/create_secret_tls.go
+++ b/pkg/cmd/create/create_secret_tls.go
@@ -46,7 +46,7 @@ var (
 
 	secretForTLSExample = templates.Examples(i18n.T(`
 	  # Create a new TLS secret named tls-secret with the given key pair
-	  kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`))
+	  kubectl create secret tls tls-secret --cert=path/to/tls.crt --key=path/to/tls.key`))
 )
 
 // CreateSecretTLSOptions holds the options for 'create secret tls' sub command


### PR DESCRIPTION
fixing: #1541 
- In kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key
- The --cert=path/to/tls.cert changed to --cert=path/to/tls.crt in help message

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
