### PR TITLE
refactor(create job): remove redundant nil check

### DIFF
--- a/pkg/cmd/create/create_job.go
+++ b/pkg/cmd/create/create_job.go
@@ -165,7 +165,7 @@ func (o *CreateJobOptions) Validate() error {
 	if (len(o.Image) == 0 && len(o.From) == 0) || (len(o.Image) != 0 && len(o.From) != 0) {
 		return fmt.Errorf("either --image or --from must be specified")
 	}
-	if o.Command != nil && len(o.Command) != 0 && len(o.From) != 0 {
+	if len(o.Command) != 0 && len(o.From) != 0 {
 		return fmt.Errorf("cannot specify --from and command")
 	}
 	return nil


### PR DESCRIPTION
Removed the nil check for a slice that was performed before it's length check.
This is linted in staticcheck as well.
https://staticcheck.dev/docs/checks#S1009