### PR TITLE
feat: Add TrafficDistribution to service describe output

### DIFF
--- a/pkg/describe/describe.go
+++ b/pkg/describe/describe.go
@@ -3155,6 +3155,9 @@ func describeService(service *corev1.Service, endpointSlices []discoveryv1.Endpo
 		if len(service.Spec.LoadBalancerSourceRanges) > 0 {
 			w.Write(LEVEL_0, "LoadBalancer Source Ranges:\t%v\n", strings.Join(service.Spec.LoadBalancerSourceRanges, ","))
 		}
+		if service.Spec.TrafficDistribution != nil && *service.Spec.TrafficDistribution != "" {
+			w.Write(LEVEL_0, "Traffic Distribution:\t%s\n", *service.Spec.TrafficDistribution)
+		}
 		if events != nil {
 			DescribeEvents(events, w)
 		}

--- a/pkg/describe/describe_test.go
+++ b/pkg/describe/describe_test.go
@@ -727,6 +727,7 @@ func getResourceList(cpu, memory string) corev1.ResourceList {
 }
 
 func TestDescribeService(t *testing.T) {
+	trafficDistributionPreferClose := "PreferClose"
 	singleStack := corev1.IPFamilyPolicySingleStack
 	testCases := []struct {
 		name           string
@@ -758,6 +759,7 @@ func TestDescribeService(t *testing.T) {
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 					InternalTrafficPolicy: ptr.To(corev1.ServiceInternalTrafficPolicyCluster),
 					HealthCheckNodePort:   32222,
+					TrafficDistribution:   &trafficDistributionPreferClose,
 				},
 				Status: corev1.ServiceStatus{
 					LoadBalancer: corev1.LoadBalancerStatus{
@@ -809,6 +811,7 @@ func TestDescribeService(t *testing.T) {
 				External Traffic Policy:  Local
 				Internal Traffic Policy:  Cluster
 				HealthCheck NodePort:     32222
+				Traffic Distribution:     PreferClose
 				Events:                   <none>
 			`)[1:],
 		},


### PR DESCRIPTION
Adds the `TrafficDistribution` field to the output of the service describe command.

This field, part of the Service specification, allows specifying preferences for traffic distribution (e.g., "PreferClose"). Including it in the describe output provides users with more complete information about the service's configuration and potential traffic routing behavior.

The change checks if `spec.trafficDistribution` is non-nil and non-empty before printing its value along with other service details.

The corresponding unit test's expected output string has been updated to match the exact spacing generated by the formatting used for the new field.
