### PR TITLE
Extend --keep-labels flag to ephemeral containers in kubectl debug

### DIFF
--- a/pkg/cmd/debug/debug.go
+++ b/pkg/cmd/debug/debug.go
@@ -199,7 +199,7 @@ func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Replace, "replace", o.Replace, i18n.T("When used with '--copy-to', delete the original Pod."))
 	cmd.Flags().StringToString("env", nil, i18n.T("Environment variables to set in the container."))
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, i18n.T("Container image to use for debug container."))
-	cmd.Flags().BoolVar(&o.KeepLabels, "keep-labels", o.KeepLabels, i18n.T("If true, keep the original pod labels.(This flag only works when used with '--copy-to')"))
+	cmd.Flags().BoolVar(&o.KeepLabels, "keep-labels", o.KeepLabels, i18n.T("If true, keep the original pod labels."))
 	cmd.Flags().BoolVar(&o.KeepAnnotations, "keep-annotations", o.KeepAnnotations, i18n.T("If true, keep the original pod annotations.(This flag only works when used with '--copy-to')"))
 	cmd.Flags().BoolVar(&o.KeepLiveness, "keep-liveness", o.KeepLiveness, i18n.T("If true, keep the original pod liveness probes.(This flag only works when used with '--copy-to')"))
 	cmd.Flags().BoolVar(&o.KeepReadiness, "keep-readiness", o.KeepReadiness, i18n.T("If true, keep the original pod readiness probes.(This flag only works when used with '--copy-to')"))
@@ -511,6 +511,18 @@ func (o *DebugOptions) debugByEphemeralContainer(ctx context.Context, pod *corev
 	klog.V(2).Infof("generated strategic merge patch for debug container: %s", patch)
 
 	pods := o.podClient.Pods(pod.Namespace)
+
+	// When --keep-labels=false, remove labels from the pod to isolate it from
+	// controllers (e.g. ReplicaSet, Service) before adding the ephemeral container.
+	// This requires a separate metadata patch since the ephemeralcontainers subresource
+	// only allows modifying ephemeral containers.
+	if !o.KeepLabels && len(pod.Labels) > 0 {
+		labelsPatch := []byte(`{"metadata":{"labels":null}}`)
+		if _, err := pods.Patch(ctx, pod.Name, types.StrategicMergePatchType, labelsPatch, metav1.PatchOptions{}); err != nil {
+			return nil, "", fmt.Errorf("error removing labels from pod: %v", err)
+		}
+	}
+
 	result, err := pods.Patch(ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers")
 	if err != nil {
 		// The apiserver will return a 404 when the EphemeralContainers feature is disabled because the `/ephemeralcontainers` subresource

--- a/pkg/cmd/debug/profiles.go
+++ b/pkg/cmd/debug/profiles.go
@@ -185,7 +185,7 @@ func (p *legacyProfile) Apply(pod *corev1.Pod, containerName string, target runt
 		p.RemoveLabels(pod)
 
 	case ephemeral:
-		// no additional modifications needed
+		p.RemoveLabels(pod)
 	}
 
 	return nil
@@ -212,6 +212,7 @@ func (p *generalProfile) Apply(pod *corev1.Pod, containerName string, target run
 		shareProcessNamespace(pod)
 
 	case ephemeral:
+		p.RemoveLabels(pod)
 		allowProcessTracing(pod, containerName)
 	}
 
@@ -234,7 +235,10 @@ func (p *baselineProfile) Apply(pod *corev1.Pod, containerName string, target ru
 		p.RemoveInitContainers(pod)
 		shareProcessNamespace(pod)
 
-	case ephemeral, node:
+	case ephemeral:
+		p.RemoveLabels(pod)
+
+	case node:
 		// no additional modifications needed
 	}
 
@@ -261,7 +265,10 @@ func (p *restrictedProfile) Apply(pod *corev1.Pod, containerName string, target 
 		p.RemoveInitContainers(pod)
 		shareProcessNamespace(pod)
 
-	case ephemeral, node:
+	case ephemeral:
+		p.RemoveLabels(pod)
+
+	case node:
 		// no additional modifications needed
 	}
 
@@ -288,7 +295,7 @@ func (p *netadminProfile) Apply(pod *corev1.Pod, containerName string, target ru
 		shareProcessNamespace(pod)
 
 	case ephemeral:
-		// no additional modifications needed
+		p.RemoveLabels(pod)
 	}
 
 	return nil
@@ -316,7 +323,7 @@ func (p *sysadminProfile) Apply(pod *corev1.Pod, containerName string, target ru
 		shareProcessNamespace(pod)
 
 	case ephemeral:
-		// no additional modifications needed
+		p.RemoveLabels(pod)
 	}
 
 	return nil


### PR DESCRIPTION
Previously, --keep-labels only worked with --copy-to (pod copy mode). This allows users to isolate a pod from its ReplicaSet/Service by stripping labels while simultaneously adding an ephemeral debug container.

When --keep-labels=false (the default) is used without --copy-to:
- A separate metadata patch removes all labels from the target pod, isolating it from controllers (ReplicaSet, Service, etc.)
- The ephemeral container is then added via the ephemeralcontainers subresource as before

All profile Apply() methods (legacy, general, baseline, restricted, netadmin, sysadmin) now call RemoveLabels in the ephemeral case, consistent with the existing podCopy behavior.

The --keep-labels flag description is updated to remove the note that it only works with --copy-to.

Fixes kubernetes/kubectl#1836

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
