### PR TITLE
kubectl run: clarify valid --restart values

### DIFF
--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -202,7 +202,7 @@ func addRunFlags(cmd *cobra.Command, opt *RunOptions) {
 	cmd.Flags().BoolVarP(&opt.TTY, "tty", "t", opt.TTY, "Allocate a TTY for the container in the pod.")
 	cmd.Flags().BoolVar(&opt.Attach, "attach", opt.Attach, "If true, wait for the Pod to start running, and then attach to the Pod as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true. With '--restart=Never' the exit code of the container process is returned.")
 	cmd.Flags().BoolVar(&opt.LeaveStdinOpen, "leave-stdin-open", opt.LeaveStdinOpen, "If the pod is started in interactive mode or with stdin, leave stdin open after the first attach completes. By default, stdin will be closed after the first attach completes.")
-	cmd.Flags().String("restart", "Always", i18n.T("The restart policy for this Pod.  Legal values [Always, OnFailure, Never]."))
+	cmd.Flags().String("restart", "Always", i18n.T("The restart policy for this Pod.  Legal values [Always, OnFailure, Never] (case-sensitive)."))
 	cmd.Flags().BoolVar(&opt.Command, "command", opt.Command, "If true and extra arguments are present, use them as the 'command' field in the container, rather than the 'args' field which is the default.")
 	cmd.Flags().BoolVar(&opt.Expose, "expose", opt.Expose, "If true, create a ClusterIP service associated with the pod.  Requires `--port`.")
 	cmd.Flags().BoolVarP(&opt.Quiet, "quiet", "q", opt.Quiet, "If true, suppress prompt messages.")
@@ -586,7 +586,7 @@ func getRestartPolicy(restart string, interactive bool) (corev1.RestartPolicy, e
 	case corev1.RestartPolicyAlways, corev1.RestartPolicyNever, corev1.RestartPolicyOnFailure:
 		return restartPolicy, nil
 	default:
-		return "", fmt.Errorf("invalid restart policy: %s", restart)
+		return "", fmt.Errorf("invalid restart policy: %s, valid values are: %s, %s, %s", restart, corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, corev1.RestartPolicyNever)
 	}
 }
 

--- a/pkg/cmd/run/run_test.go
+++ b/pkg/cmd/run/run_test.go
@@ -34,6 +34,7 @@ func TestGetRestartPolicy(t *testing.T) {
 		interactive bool
 		expected    corev1.RestartPolicy
 		expectErr   bool
+		expectedErr string
 	}{
 		{
 			input:    "",
@@ -63,8 +64,14 @@ func TestGetRestartPolicy(t *testing.T) {
 			expected: corev1.RestartPolicyNever,
 		},
 		{
-			input:     "foo",
-			expectErr: true,
+			input:       "foo",
+			expectErr:   true,
+			expectedErr: "invalid restart policy: foo, valid values are: Always, OnFailure, Never",
+		},
+		{
+			input:       "never",
+			expectErr:   true,
+			expectedErr: "invalid restart policy: never, valid values are: Always, OnFailure, Never",
 		},
 	}
 	for _, test := range tests {
@@ -74,6 +81,9 @@ func TestGetRestartPolicy(t *testing.T) {
 		}
 		if !test.expectErr && err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+		if test.expectErr && err != nil && err.Error() != test.expectedErr {
+			t.Errorf("expected error: %q, saw: %q", test.expectedErr, err.Error())
 		}
 		if !test.expectErr && policy != test.expected {
 			t.Errorf("expected: %s, saw: %s (%s:%v)", test.expected, policy, test.input, test.interactive)


### PR DESCRIPTION
## What this PR does
Improves kubectl run --restart guidance without changing parsing behavior:
- keeps restart policy parsing case-sensitive
- makes --restart help text explicitly case-sensitive
- improves invalid --restart error message to list allowed values (Always, OnFailure, Never)
- adds focused unit coverage for invalid values, including lowercase never

## Why
This follows maintainer guidance in kubernetes/kubectl#1504 (/triage accepted with caveat not to make parsing case-insensitive) and aligns with the direction noted in kubernetes/kubernetes#138188 to improve allowed-values messaging.

Fixes kubernetes/kubectl#1504
